### PR TITLE
instrument broker read errors (WIP)

### DIFF
--- a/v2/pkg/broker/read_api.go
+++ b/v2/pkg/broker/read_api.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LiveRamp/gazette/v2/pkg/client"
 	"github.com/LiveRamp/gazette/v2/pkg/fragment"
+	"github.com/LiveRamp/gazette/v2/pkg/metrics"
 	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -41,6 +42,7 @@ func (svc *Service) Read(req *pb.ReadRequest, stream pb.Journal_ReadServer) erro
 	if err = serveRead(stream, req, &res.Header, res.replica.index); err == context.Canceled {
 		err = nil // Gracefully terminate RPC.
 	} else if err != nil {
+		metrics.ReadRequestTotal.WithLabelValues(metrics.Fail).Inc()
 		log.WithFields(log.Fields{"err": err, "req": req}).Warn("failed to serve Read")
 	}
 	return err

--- a/v2/pkg/metrics/metrics.go
+++ b/v2/pkg/metrics/metrics.go
@@ -11,6 +11,7 @@ const (
 	CommitsTotalKey                   = "gazette_commits_total"
 	RecoveryLogRecoveredBytesTotalKey = "gazette_recoverylog_recovered_bytes_total"
 	StoreRequestKey                   = "gazette_store_requests_total"
+	ReadRequestKey                    = "gazette_read_request"
 
 	Fail = "fail"
 	Ok   = "ok"
@@ -34,6 +35,10 @@ var (
 		Name: StoreRequestKey,
 		Help: "Cumulative number of fragment store operations.",
 	}, []string{"provider", "operation", "status"})
+	ReadRequestTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: ReadRequestKey,
+		Help: "Cumulative number of borker read requests.",
+	}, []string{"status"})
 )
 
 // GazetteBrokerCollectors lists collectors used by the gazette broker.
@@ -43,6 +48,7 @@ func GazetteBrokerCollectors() []prometheus.Collector {
 		CommitsTotal,
 		RecoveryLogRecoveredBytesTotal,
 		StoreRequestTotal,
+		ReadRequestTotal,
 	}
 }
 


### PR DESCRIPTION
I wanted to be able to observe read failures so I added this metric to stat them. I did not add a metric for Read successes because it is a streaming API and I am not sure how actionable a dip/spike in those values would be.
This also strictly stats errors that are a result of the read pipeline. If there is a Read RPC request and there is an error resolving the host to serve the request that is not included in this stat. Perhaps we can consider adding another metric for that. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/191)
<!-- Reviewable:end -->
