### PR TITLE
allocator: sparse max-flow solver & flow network

### DIFF
--- a/allocator/alloc_state.go
+++ b/allocator/alloc_state.go
@@ -28,6 +28,7 @@ type State struct {
 	Zones       []string // Sorted and unique Zones of |Members|.
 	ZoneSlots   []int    // Total number of item slots summed across all |Members| of each Zone.
 	ItemSlots   int      // Total desired replication slots summed across all |Items|.
+	MemberSlots int      // Total available slots for replication summed across all |Members|.
 	NetworkHash uint64   // Content-sum which captures Items & Members, and their constraints.
 
 	// Number of total Assignments, and primary Assignments by Member.
@@ -66,6 +67,7 @@ func (s *State) observe() {
 	s.Zones = s.Zones[:0]
 	s.ZoneSlots = s.ZoneSlots[:0]
 	s.ItemSlots = 0
+	s.MemberSlots = 0
 	s.NetworkHash = 0
 	s.MemberTotalCount = make([]int, len(s.Members))
 	s.MemberPrimaryCount = make([]int, len(s.Members))
@@ -73,6 +75,7 @@ func (s *State) observe() {
 	// Walk Members to:
 	//  * Group the set of ordered |Zones| across all Members.
 	//  * Initialize |ZoneSlots|.
+	//  * Initialize |MemberSlots|.
 	//  * Initialize |NetworkHash|.
 	for i := range s.Members {
 		var m = memberAt(s.Members, i)
@@ -88,6 +91,7 @@ func (s *State) observe() {
 		}
 
 		s.ZoneSlots[zone] += slots
+		s.MemberSlots += slots
 		s.NetworkHash = foldCRC(s.NetworkHash, s.Members[i].Raw.Key, slots)
 	}
 

--- a/allocator/alloc_state_test.go
+++ b/allocator/alloc_state_test.go
@@ -38,6 +38,7 @@ func (s *AllocStateSuite) TestExtractOverFixture(c *gc.C) {
 		// Expect ordered Zones and slot counts were extracted.
 		c.Check(s.Zones, gc.DeepEquals, []string{"us-east", "us-west"})
 		c.Check(s.ZoneSlots, gc.DeepEquals, []int{3, 3})
+		c.Check(s.MemberSlots, gc.Equals, 6)
 		c.Check(s.ItemSlots, gc.Equals, 3)
 		c.Check(s.NetworkHash, gc.Equals, uint64(0x175a17d95541fa12))
 

--- a/allocator/flow_network.go
+++ b/allocator/flow_network.go
@@ -49,6 +49,8 @@ import (
 //
 // TODO(johnny): Update this diagram to reflect the Overflow node (Issue #157).
 //
+// Deprecated: flowNetwork is deprecated, along with the push_relabel package,
+// in favor of sparseFlowNetwork & sparse_push_relabel.
 type flowNetwork struct {
 	source    pr.Node
 	members   []pr.Node

--- a/allocator/sparse_flow_network.go
+++ b/allocator/sparse_flow_network.go
@@ -1,0 +1,407 @@
+package allocator
+
+import (
+	"sort"
+	"strings"
+
+	pr "go.gazette.dev/core/allocator/sparse_push_relabel"
+	"go.gazette.dev/core/keyspace"
+)
+
+// sparseFlowNetwork models an allocator.State as a flow network, representing
+// Items, "Zone Items" (which is an Item within the context of a single zone),
+// and Members. Pictorially, the network resembles:
+//
+//               Items        Zone-Items         Members
+//               -----        ----------         -------
+//
+//                            +-------+
+//                            |       |---\    +---------+
+//                           >|item1/A|    --->|         |
+//                         -/ |       |\       |A/memberX|\
+//                        /   +-------+ -\    ^|         | -\
+//              +-----+ -/    +-------+   -\ / +---------+   \
+//              |     |/      |       |     /\ +---------+    \
+//             >|item1|------>|item1/B|    /  >|         |     -\
+// +------+  -/ |     |       |       |\  /    |A/memberY|--\    \ +--------+
+// |      |-/   +-----+       +-------+ \/    >|         |   ---\ >|        |
+// |source|                             /\  -/ +---------+       ->| target |
+// |      |-\   +-----+       +-------+/  \/                      >|        |
+// +------+  -\ |     |       |       |  -/\                    -/ +--------+
+//             >|item2|------>|item2/A|-/   \                  /
+//              |     |\      |       |      \ +---------+   -/
+//              +-----+ -\    +-------+       v|         | -/
+//                        \   +-------+        |B/memberZ|/
+//                         -\ |       |    --->|         |
+//                           >|item2/B|---/    +---------+
+//                            |       |
+//                            +-------+
+//
+// The network also represents a number of constraints and goals:
+//
+// - Desired Item replication is captured by the capacity from source to Item.
+// - Zone replication constraints (distribution of each Item across 2+ zones) are
+//   captured in arcs from Items to Zone Items. Goals for maintaining current
+//   assignments and balancing evenly across zones are also expressed.
+// - A preference for current assignments is reflected in arcs from Zone Items
+//   to Members.
+// - Desired "fair share" scaled capacity and upper-bound capacity is reflected
+//   by arcs from Members to the Sink.
+//
+// The basic strategy used is to greedily coerce the push/relabel solver towards
+// a solution which achieves optimization goals (minimal updates & even balancing)
+// while still staying within the algorithmic scaffolding of push/relabel,
+// ensuring that a correct maximum-flow solution is ultimately arrived at.
+//
+// This coercing is expressed through the order in which Arcs are presented to the
+// solver, and also by strategically constraining the capacities of those Arcs.
+// As the solver finds it is unable to follow the "garden path" (not all network
+// excess can be allocated), and as back-tracking builds "pressure" in the network
+// (expressed via node heights), the relevant Arc capacities at each step are
+// relaxed until a maximal assignment is achieved.
+//
+type sparseFlowNetwork struct {
+	*State
+
+	firstItemNodeID     pr.NodeID // First Item NodeID in the graph.
+	firstZoneItemNodeID pr.NodeID // First Zone-Item NodeID in the graph.
+	firstMemberNodeID   pr.NodeID // First Member NodeID in the graph.
+
+	// For each zone-item, the offset into State.Assignments of its first assignment.
+	zoneItemAssignments []keyspace.KeyValues
+	// For each zone, an index of member ID suffix to its NodeID.
+	memberSuffixIdxByZone []map[string]pr.NodeID
+	// For each zone, a slice of Arcs to all members of that zone.
+	allZoneItemArcsByZone [][]pr.Arc
+
+	// scratch is a small slice of Arcs for (re)use without allocating. We'll
+	// want up-to the number of zones, or the number of Assignments of an Item
+	// within a zone -- both should be small, but if we overflow that's fine,
+	// as append() will just allocate from heap instead.
+	scratch [8]pr.Arc
+}
+
+const (
+	// By network construction, the push/relabel algorithm will relabel an Item
+	// node to a RelativeHeight() of 1 (relative to the source node) just prior
+	// to pushing back to the source, which terminates the algorithm.
+	//
+	// Where we ordinarily require an Item to be replicated across two zones, if
+	// we reach this height, we'll instead allow a single zone to hold all Item
+	// replicas (as the alternative is not fully replicating the Item at all).
+	itemOverflowThreshold = 1
+	// Also by network construction, if a Member node is allowed to reach a
+	// RelativeHeight() of 1, then we may also cause |itemOverflowThreshold| to
+	// be breached. Eg:
+	// - Member height S+1 pushes along residual to ZoneItem height S.
+	// - ZoneItem height S pushes to Item having height S-1.
+	// - Item is relabeled to S+1.
+	//
+	// Ideally we evenly balance Items across Members, but we'd rather a Member
+	// take on more than its fair share of Items than cause an Item to not be
+	// replicated across at least two zones. In network terms, we'd rather a
+	// Member overflow before we allow an Item to overflow, and we thus never
+	// want a Member to reach RelativeHeight of 1 if capacity remains.
+	//
+	// *However*, note that a relabeling may take us from height S-1 => S+1,
+	// skipping S, so we must bound to RelativeHeight() of -1 to ensure this
+	// never happens.
+	memberOverflowThreshold = -1
+
+	pageItemArcsUniform    = pr.PageInitial + 1
+	pageItemArcsRMinusOne  = pageItemArcsUniform + 1
+	pageZoneItemAllMembers = pageItemArcsRMinusOne + 1
+)
+
+func newSparseFlowNetwork(s *State) *sparseFlowNetwork {
+	var fs = &sparseFlowNetwork{State: s}
+
+	// Nodes are ordered as:
+	//  - Source node, then
+	//  - Sink node, then
+	//  - Item Nodes, then
+	//  - Zone-Item Nodes, then
+	//  - Member Nodes.
+	fs.firstItemNodeID = pr.SinkID + 1 // == 2.
+	fs.firstZoneItemNodeID = fs.firstItemNodeID + pr.NodeID(len(s.Items))
+	fs.firstMemberNodeID = fs.firstZoneItemNodeID + pr.NodeID(len(s.Items)*len(s.Zones))
+
+	// Left-join |Items| with |Assignments| (which is ordered on Item ID,
+	// Member zone, Member suffix) to build an index of zone-item to the
+	// offset of its first Assignment (or, the offset to where its Assignment
+	// would place if it had one).
+	fs.zoneItemAssignments = make([]keyspace.KeyValues, len(s.Items)*len(s.Zones))
+
+	var it = LeftJoin{
+		LenL: len(s.Items),
+		LenR: len(s.Assignments),
+		Compare: func(l, r int) int {
+			return strings.Compare(itemAt(s.Items, l).ID, assignmentAt(s.Assignments, r).ItemID)
+		},
+	}
+	for cur, ok := it.Next(); ok; cur, ok = it.Next() {
+		var item = cur.Left
+		var assignments = s.Assignments[cur.RightBegin:cur.RightEnd]
+
+		// Left-join zones with |assignments| of this |item|.
+		var it2 = LeftJoin{
+			LenL: len(s.Zones),
+			LenR: len(assignments),
+			Compare: func(l, r int) int {
+				return strings.Compare(s.Zones[l], assignmentAt(assignments, r).MemberZone)
+			},
+		}
+		for cur2, ok2 := it2.Next(); ok2; cur2, ok2 = it2.Next() {
+			var zoneItem = item*len(s.Zones) + cur2.Left
+			fs.zoneItemAssignments[zoneItem] = assignments[cur2.RightBegin:cur2.RightEnd]
+		}
+	}
+
+	fs.memberSuffixIdxByZone = make([]map[string]pr.NodeID, len(s.Zones))
+	fs.allZoneItemArcsByZone = make([][]pr.Arc, len(s.Zones))
+
+	// Left-join |Zones| with |Members| (which is ordered on Member zone, Member suffix).
+	it = LeftJoin{
+		LenL: len(s.Zones),
+		LenR: len(s.Members),
+		Compare: func(l, r int) int {
+			return strings.Compare(s.Zones[l], memberAt(s.Members, r).Zone)
+		},
+	}
+	for cur, ok := it.Next(); ok; cur, ok = it.Next() {
+		var zone = cur.Left
+
+		fs.memberSuffixIdxByZone[zone] = make(map[string]pr.NodeID)
+		fs.allZoneItemArcsByZone[zone] = make([]pr.Arc, 0, cur.RightEnd-cur.RightBegin)
+
+		for m := cur.RightBegin; m != cur.RightEnd; m++ {
+			var id = fs.firstMemberNodeID + pr.NodeID(m)
+			fs.memberSuffixIdxByZone[zone][memberAt(s.Members, m).Suffix] = id
+
+			fs.allZoneItemArcsByZone[zone] = append(fs.allZoneItemArcsByZone[zone],
+				pr.Arc{To: id, Capacity: 1})
+		}
+	}
+	return fs
+}
+
+func (fs *sparseFlowNetwork) Nodes() int {
+	return int(fs.firstMemberNodeID) + len(fs.Members)
+}
+
+func (fs *sparseFlowNetwork) InitialHeight(id pr.NodeID) pr.Height {
+	if id < fs.firstZoneItemNodeID {
+		return 3 // Item node.
+	} else if id < fs.firstMemberNodeID {
+		return 2 // Zone-Item node.
+	} else {
+		return 1 // Member node.
+	}
+}
+
+func (fs *sparseFlowNetwork) Arcs(mf *pr.MaxFlow, id pr.NodeID, page pr.PageToken) ([]pr.Arc, pr.PageToken) {
+	if id == pr.SourceID {
+		return fs.buildSourceArcs(), pr.PageEOF // Arcs from the Source to each Item.
+
+	} else if id == pr.SinkID {
+		// push/relabel never discharges from the sink, so we never expect to
+		// see a corresponding Arcs() call.
+		panic("unexpected Arcs call with id == pr.SinkID")
+
+	} else if id < fs.firstZoneItemNodeID {
+		var item = int(id - fs.firstItemNodeID)
+		var r = itemAt(fs.Items, item).DesiredReplication()
+
+		// Enumerate Arcs from the Item to each of its Zone-Item Nodes.
+		// If there is only one zone, or we will next push back to the Source,
+		// then do not constrain the capacity of each Zone-Item Arc
+		// (all of the Item's flow may go to any Zone-Item).
+		if len(fs.Zones) == 1 || mf.RelativeHeight(id) == itemOverflowThreshold {
+			return fs.buildAllItemArcs(item, r), pr.PageEOF
+		}
+
+		// Otherwise, enumerate arcs which prefer:
+		// - To maintain current Item / zone Assignments, then
+		// - Uniformly balancing the Item across zones, then
+		// - Any zone, so long as at least two zones are utilized.
+		switch page {
+		case pr.PageInitial:
+			return fs.buildCurrentItemArcs(item, max(r-1, 1)), pageItemArcsUniform
+		case pageItemArcsUniform:
+			var uniform = scaleAndRound(r, 1, len(fs.Zones))
+			return fs.buildAllItemArcs(item, uniform), pageItemArcsRMinusOne
+		case pageItemArcsRMinusOne:
+			return fs.buildAllItemArcs(item, max(r-1, 1)), pr.PageEOF
+		default:
+			panic("invalid PageToken")
+		}
+
+	} else if id < fs.firstMemberNodeID {
+		var zoneItem = int(id - fs.firstZoneItemNodeID)
+
+		// Cycle through two pages of arcs:
+		// - Arcs which reflect current Assignments of the Zone-Item to zone Members.
+		// - Arcs which represent the total set of zone Members.
+		// Intuitively: we prefer to keep current Member Assignments, but will allow
+		// a new assignment to any of the zone's Members.
+		switch page {
+		case pr.PageInitial:
+			return fs.buildCurrentZoneItemArcs(zoneItem), pageZoneItemAllMembers
+		case pageZoneItemAllMembers:
+			return fs.allZoneItemArcsByZone[zoneItem%len(fs.Zones)], pr.PageEOF
+		default:
+			panic("invalid PageToken")
+		}
+	} else {
+		var member = int(id - fs.firstMemberNodeID)
+		return fs.buildMemberArc(mf, id, member), pr.PageEOF
+	}
+}
+
+// buildSourceArcs enumerates an Arc for each Item node, nominally having capacity
+// of the Item's desired replication. If the total number of Item slots greatly
+// exceeds Member slots, this degrades the performance and stability of the push/
+// relabel solver; we therefore globally bound Item capacities to the number of
+// available Member slots.
+func (fs *sparseFlowNetwork) buildSourceArcs() []pr.Arc {
+	var arcs = make([]pr.Arc, len(fs.Items))
+	var remaining = fs.MemberSlots
+
+	for item := range fs.Items {
+		var c = itemAt(fs.Items, item).DesiredReplication()
+
+		if c > remaining {
+			c = remaining
+		}
+		remaining -= c
+
+		arcs[item] = pr.Arc{
+			To:       fs.firstItemNodeID + pr.NodeID(item),
+			Capacity: pr.Rate(c),
+		}
+	}
+	return arcs
+}
+
+// buildAllItemArcs enumerates an Arc for each ZoneItem node of the Item,
+// each having capacity C.
+func (fs *sparseFlowNetwork) buildAllItemArcs(item int, C int) []pr.Arc {
+	var (
+		arcs = fs.scratch[:0]
+		lz   = len(fs.Zones)
+	)
+
+	for zone := 0; zone != lz; zone++ {
+		arcs = append(arcs, pr.Arc{
+			To:       fs.firstZoneItemNodeID + pr.NodeID(item*lz+zone),
+			Capacity: pr.Rate(C),
+		})
+	}
+	return arcs
+}
+
+// buildCurrentItemArcs enumerates an Arc for each ZoneItem of the Item
+// having current Assignments. Arc capacities are the smaller of |bound|
+// and the number of current Assignments.
+func (fs *sparseFlowNetwork) buildCurrentItemArcs(item int, bound int) []pr.Arc {
+	var (
+		arcs = fs.scratch[:0]
+		lz   = len(fs.Zones)
+	)
+	for zone := 0; zone != lz; zone++ {
+		var n = len(fs.zoneItemAssignments[item*lz+zone])
+		if n > bound {
+			n = bound
+		}
+		if n != 0 {
+			arcs = append(arcs, pr.Arc{
+				To:        fs.firstZoneItemNodeID + pr.NodeID(item*lz+zone),
+				Capacity:  pr.Rate(n),
+				PushFront: true,
+			})
+		}
+	}
+	return arcs
+}
+
+// buildMemberArc from member |member| to the sink. Its capacity is:
+// - The scaled proportion of the member's slots relative to item slots
+//   (rounded up), or:
+// - If the node height is over-threshold, the capacity is the full number of
+//   member slots.
+// Intuitively, the Member node will resist having more than its fair share of
+// assignments until sufficient pressure builds within the network to indicate
+// that not all assignments can otherwise be made. At this point the member will
+// allow assignments up to its full capacity.
+func (fs *sparseFlowNetwork) buildMemberArc(mf *pr.MaxFlow, id pr.NodeID, member int) []pr.Arc {
+	var c = memberAt(fs.Members, member).ItemLimit()
+
+	if mf.RelativeHeight(id) < memberOverflowThreshold {
+		c = scaleAndRound(c, fs.ItemSlots, fs.MemberSlots)
+	}
+	fs.scratch[0] = pr.Arc{
+		To:       pr.SinkID,
+		Capacity: pr.Rate(c),
+	}
+	return fs.scratch[:1]
+}
+
+// buildCurrentZoneItemArcs from zone-item |zoneItem| to each Member node of the
+// zone having a current assignment.
+func (fs *sparseFlowNetwork) buildCurrentZoneItemArcs(zoneItem int) []pr.Arc {
+	var (
+		arcs = fs.scratch[:0]
+		zone = zoneItem % len(fs.Zones)
+	)
+	for _, a := range fs.zoneItemAssignments[zoneItem] {
+		if id, ok := fs.memberSuffixIdxByZone[zone][a.Decoded.(Assignment).MemberSuffix]; ok {
+			arcs = append(arcs, pr.Arc{
+				To:        id,
+				Capacity:  1,
+				PushFront: true,
+			})
+		}
+	}
+	return arcs
+}
+
+// extractAssignments appends and returns the set of ordered []Assignment
+// implied by the MaxFlow solution.
+func (fs *sparseFlowNetwork) extractAssignments(g *pr.MaxFlow, out []Assignment) []Assignment {
+	var lz = len(fs.Zones)
+
+	for item := range fs.Items {
+		var itemID = itemAt(fs.Items, item).ID
+		var sortFrom = len(out)
+
+		for zone := 0; zone != lz; zone++ {
+			var nodeID = fs.firstZoneItemNodeID + pr.NodeID(item*lz+zone)
+
+			g.Flows(nodeID, func(flow pr.Flow) {
+				var member = memberAt(fs.Members, int(flow.To-fs.firstMemberNodeID))
+
+				out = append(out, Assignment{
+					ItemID:       itemID,
+					MemberZone:   member.Zone,
+					MemberSuffix: member.Suffix,
+				})
+			})
+		}
+		// Sort the portion just added to |out| under natural Assignment order.
+		sort.Slice(out[sortFrom:], func(i, j int) bool {
+			return compareAssignment(out[i+sortFrom], out[j+sortFrom]) < 0
+		})
+	}
+	return out
+}
+
+// scaleAndRound returns |c * min(num / denom, 1)|, using integer math and rounding up.
+func scaleAndRound(c, num, denom int) int {
+	if num > denom {
+		return c
+	}
+	if c *= num; c%denom != 0 {
+		c += denom
+	}
+	return c / denom
+}

--- a/allocator/sparse_flow_network_test.go
+++ b/allocator/sparse_flow_network_test.go
@@ -1,0 +1,361 @@
+package allocator
+
+import (
+	"context"
+
+	gc "github.com/go-check/check"
+	pr "go.gazette.dev/core/allocator/sparse_push_relabel"
+	"go.gazette.dev/core/etcdtest"
+	"go.gazette.dev/core/keyspace"
+)
+
+type SparseSuite struct{}
+
+func (s *SparseSuite) TestOverKeySpaceFixture(c *gc.C) {
+	var client, ctx = etcdtest.TestClient(), context.Background()
+	defer etcdtest.Cleanup()
+	buildAllocKeySpaceFixture(c, ctx, client)
+
+	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
+	var state = NewObservedState(ks, MemberKey(ks, "us-west", "baz"))
+	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
+
+	const (
+		I1 = pr.SinkID + 1 + iota
+		I2
+		I1E
+		I1W
+		I2E
+		I2W
+		MBar
+		MFoo
+		MBaz
+	)
+	var fn = newSparseFlowNetwork(state)
+
+	c.Check(fn.firstItemNodeID, gc.Equals, I1)
+	c.Check(fn.firstZoneItemNodeID, gc.Equals, I1E)
+	c.Check(fn.firstMemberNodeID, gc.Equals, MBar)
+
+	c.Check(fn.zoneItemAssignments, gc.DeepEquals, []keyspace.KeyValues{
+		state.Assignments[0:1], // item-1#us-east#foo#1
+		state.Assignments[1:2], // item-1#us-west#baz#0
+		// item-missing#us-west#baz#0 skipped (not a current item).
+		// item-two#missing#member#2 skipped (not a current zone).
+		state.Assignments[4:5], // item-two#us-east#bar#0
+		state.Assignments[5:6], // item-two#us-west#baz#1
+	})
+	c.Check(fn.memberSuffixIdxByZone, gc.DeepEquals, []map[string]pr.NodeID{
+		{"bar": MBar, "foo": MFoo}, // Zone us-east.
+		{"baz": MBaz},              // Zone us-west.
+	})
+	c.Check(fn.allZoneItemArcsByZone, gc.DeepEquals, [][]pr.Arc{
+		{{To: MBar, Capacity: 1}, {To: MFoo, Capacity: 1}}, // us-east.
+		{{To: MBaz, Capacity: 1}},                          // us-west.
+	})
+
+	var mf = pr.FindMaxFlow(fn)
+
+	// Verify expected Source => Item Arcs.
+	verifyArcs(c, fn, mf, pr.SourceID, [][]pr.Arc{{
+		{To: I1, Capacity: 2},
+		{To: I2, Capacity: 1},
+	}})
+
+	// Verify Item => ZoneItem Arcs.
+	verifyArcs(c, fn, mf, I1, [][]pr.Arc{
+		{
+			{To: I1E, Capacity: 1, PushFront: true},
+			{To: I1W, Capacity: 1, PushFront: true},
+		},
+		{
+			{To: I1E, Capacity: 1}, // Uniform.
+			{To: I1W, Capacity: 1},
+		},
+		{
+			{To: I1E, Capacity: 1}, // R - 1.
+			{To: I1W, Capacity: 1},
+		},
+	})
+	verifyArcs(c, fn, mf, I2, [][]pr.Arc{
+		{
+			{To: I2E, Capacity: 1, PushFront: true},
+			{To: I2W, Capacity: 1, PushFront: true},
+		},
+		{
+			{To: I2E, Capacity: 1}, // Uniform.
+			{To: I2W, Capacity: 1},
+		},
+		{
+			{To: I2E, Capacity: 1}, // R - 1.
+			{To: I2W, Capacity: 1},
+		},
+	})
+
+	// Verify ZoneItem => Member arcs.
+	verifyArcs(c, fn, mf, I1E, [][]pr.Arc{
+		{{To: MFoo, Capacity: 1, PushFront: true}},
+		{
+			{To: MBar, Capacity: 1},
+			{To: MFoo, Capacity: 1},
+		},
+	})
+	verifyArcs(c, fn, mf, I2E, [][]pr.Arc{
+		{{To: MBar, Capacity: 1, PushFront: true}},
+		{
+			{To: MBar, Capacity: 1},
+			{To: MFoo, Capacity: 1},
+		},
+	})
+	verifyArcs(c, fn, mf, I1W, [][]pr.Arc{
+		{{To: MBaz, Capacity: 1, PushFront: true}},
+		{{To: MBaz, Capacity: 1}},
+	})
+
+	// Verify Member => Sink arc.
+	verifyArcs(c, fn, mf, MFoo, [][]pr.Arc{
+		{{To: pr.SinkID, Capacity: 1}}, // Scaling: 2 * 3/6 => 1.
+	})
+	verifyArcs(c, fn, mf, MBar, [][]pr.Arc{
+		{{To: pr.SinkID, Capacity: 1}}, // Scaling: 1 * 3/6 => 1.
+	})
+	verifyArcs(c, fn, mf, MBaz, [][]pr.Arc{
+		{{To: pr.SinkID, Capacity: 2}}, // Scaling: 3 * 3/6 => 2.
+	})
+
+	c.Check(fn.extractAssignments(mf, nil), gc.DeepEquals, []Assignment{
+		// Expect "item-1"'s max-flow Assignments are unchanged from the fixture.
+		{ItemID: "item-1", MemberZone: "us-east", MemberSuffix: "foo"},
+		{ItemID: "item-1", MemberZone: "us-west", MemberSuffix: "baz"},
+		// "item-2" was over-replicated. Expect one Assignment is unchanged,
+		// and the other is removed (choice is arbitrary but deterministic).
+		{ItemID: "item-two", MemberZone: "us-west", MemberSuffix: "baz"},
+	})
+}
+
+func (s *SparseSuite) TestMemberScalingOverflow(c *gc.C) {
+	var client, ctx = etcdtest.TestClient(), context.Background()
+	defer etcdtest.Cleanup()
+
+	for k, v := range map[string]string{
+		"/root/items/item-1": `{"R": 2}`,
+		"/root/items/item-2": `{"R": 2}`,
+
+		"/root/members/A#one": `{"R": 2}`,
+		"/root/members/A#two": `{"R": 6}`,
+	} {
+		var _, err = client.Put(ctx, k, v)
+		c.Assert(err, gc.IsNil)
+	}
+	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
+	var state = NewObservedState(ks, MemberKey(ks, "A", "one"))
+	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
+
+	const (
+		I1 = pr.SinkID + 1 + iota
+		I2
+		I1A
+		I2A
+		MOne
+		MTwo
+	)
+	// Use noopNetwork to inspect arcs prior to overflow being reached.
+	var fn = newSparseFlowNetwork(state)
+	var mf = pr.FindMaxFlow(noopNetwork{fn})
+
+	// Verify expected Source => Item Arcs.
+	verifyArcs(c, fn, mf, pr.SourceID, [][]pr.Arc{{
+		{To: I1, Capacity: 2},
+		{To: I2, Capacity: 2},
+	}})
+	// Verify Item => ZoneItem Arcs.
+	verifyArcs(c, fn, mf, I1, [][]pr.Arc{
+		{{To: I1A, Capacity: 2}},
+	})
+	verifyArcs(c, fn, mf, I2, [][]pr.Arc{
+		{{To: I2A, Capacity: 2}},
+	})
+	// Verify ZoneItem => Member arcs.
+	verifyArcs(c, fn, mf, I1A, [][]pr.Arc{
+		{}, // No current assignments.
+		{
+			{To: MOne, Capacity: 1},
+			{To: MTwo, Capacity: 1},
+		},
+	})
+	verifyArcs(c, fn, mf, I2A, [][]pr.Arc{
+		{},
+		{
+			{To: MOne, Capacity: 1},
+			{To: MTwo, Capacity: 1},
+		},
+	})
+	// Verify initial Member => Sink arc.
+	verifyArcs(c, fn, mf, MOne, [][]pr.Arc{
+		{{To: pr.SinkID, Capacity: 1}}, // Scaling: 2 * 4/8 => 1.
+	})
+	verifyArcs(c, fn, mf, MTwo, [][]pr.Arc{
+		{{To: pr.SinkID, Capacity: 3}}, // Scaling: 6 * 4/8 => 3.
+	})
+
+	mf = pr.FindMaxFlow(fn) // Solve, reaching overflow.
+
+	// Expect that push/relabel raises the height of MOne into "overflow",
+	// where instead of pushing flow back to the source it instead
+	// allows more flow through to the Sink (aka, assignments to the
+	// member), up to the member's capacity.
+	verifyArcs(c, fn, mf, MOne, [][]pr.Arc{
+		{{To: pr.SinkID, Capacity: 2}}, // Overflow mode.
+	})
+	// Expect both items are fully assigned, despite surpassing
+	// our desired MOne scaling.
+	c.Check(fn.extractAssignments(mf, nil), gc.DeepEquals, []Assignment{
+		{ItemID: "item-1", MemberZone: "A", MemberSuffix: "one"},
+		{ItemID: "item-1", MemberZone: "A", MemberSuffix: "two"},
+		{ItemID: "item-2", MemberZone: "A", MemberSuffix: "one"},
+		{ItemID: "item-2", MemberZone: "A", MemberSuffix: "two"},
+	})
+}
+
+func (s *SparseSuite) TestZonePlacementOverflow(c *gc.C) {
+	var client, ctx = etcdtest.TestClient(), context.Background()
+	defer etcdtest.Cleanup()
+
+	for k, v := range map[string]string{
+		"/root/items/item-1": `{"R": 2}`,
+		"/root/items/item-2": `{"R": 2}`,
+		"/root/items/item-3": `{"R": 2}`,
+
+		"/root/members/A#one":   `{"R": 2}`,
+		"/root/members/A#two":   `{"R": 2}`,
+		"/root/members/B#three": `{"R": 2}`,
+	} {
+		var _, err = client.Put(ctx, k, v)
+		c.Assert(err, gc.IsNil)
+	}
+	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
+	var state = NewObservedState(ks, MemberKey(ks, "A", "one"))
+	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
+
+	const (
+		I1 = pr.SinkID + 1 + iota
+		_  // I2
+		_  // I3
+		I1A
+		I1B
+	)
+	var fn = newSparseFlowNetwork(state)
+	var mf = pr.FindMaxFlow(noopNetwork{fn})
+
+	// Expect that initially, we constrain Item => ZoneItem arcs such that
+	// balanced assignments are preferred, and we require at least two
+	// zones are utilized.
+	verifyArcs(c, fn, mf, I1, [][]pr.Arc{
+		{}, // No current assignments.
+		{
+			{To: I1A, Capacity: 1}, // Uniform.
+			{To: I1B, Capacity: 1},
+		},
+		{
+			{To: I1A, Capacity: 1}, // R - 1.
+			{To: I1B, Capacity: 1},
+		},
+	})
+
+	mf = pr.FindMaxFlow(fn) // Solve, reaching overflow.
+
+	// Expect that push/relabel raises the height of I3 into "overflow"
+	// where instead of pushing flow back to the source, it instead
+	// allows all R flow through to a single zone. In other words, we
+	// relax the two-zone constraint if it's otherwise not possible to
+	// assign all items.
+	verifyArcs(c, fn, mf, I1, [][]pr.Arc{
+		{
+			{To: I1A, Capacity: 2},
+			{To: I1B, Capacity: 2},
+		},
+	})
+	// Expect all items are fully assigned, though item-3 is allocated
+	// to a single zone.
+	c.Check(fn.extractAssignments(mf, nil), gc.DeepEquals, []Assignment{
+		{ItemID: "item-1", MemberZone: "A", MemberSuffix: "one"},
+		{ItemID: "item-1", MemberZone: "A", MemberSuffix: "two"},
+		{ItemID: "item-2", MemberZone: "A", MemberSuffix: "two"},
+		{ItemID: "item-2", MemberZone: "B", MemberSuffix: "three"},
+		{ItemID: "item-3", MemberZone: "A", MemberSuffix: "one"},
+		{ItemID: "item-3", MemberZone: "B", MemberSuffix: "three"},
+	})
+}
+
+func (s *SparseSuite) TestZoneBalancing(c *gc.C) {
+	var client, ctx = etcdtest.TestClient(), context.Background()
+	defer etcdtest.Cleanup()
+
+	for k, v := range map[string]string{
+		"/root/items/item-1": `{"R": 6}`,
+
+		"/root/members/A#one":   `{"R": 2}`,
+		"/root/members/B#two":   `{"R": 2}`,
+		"/root/members/C#three": `{"R": 2}`,
+
+		"/root/assign/item-1#A#one#0":   ``,
+		"/root/assign/item-1#C#three#1": ``,
+	} {
+		var _, err = client.Put(ctx, k, v)
+		c.Assert(err, gc.IsNil)
+	}
+	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
+	var state = NewObservedState(ks, MemberKey(ks, "us-west", "baz"))
+	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
+
+	const (
+		I1 = pr.SinkID + 1 + iota
+		I1A
+		I1B
+		I1C
+	)
+	var fn = newSparseFlowNetwork(state)
+	var mf = pr.FindMaxFlow(noopNetwork{fn})
+
+	verifyArcs(c, fn, mf, I1, [][]pr.Arc{
+		{
+			{To: I1A, Capacity: 1, PushFront: true},
+			{To: I1C, Capacity: 1, PushFront: true},
+		},
+		{
+			{To: I1A, Capacity: 2}, // Uniform.
+			{To: I1B, Capacity: 2},
+			{To: I1C, Capacity: 2},
+		},
+		{
+			{To: I1A, Capacity: 5}, // R - 1.
+			{To: I1B, Capacity: 5},
+			{To: I1C, Capacity: 5},
+		},
+	})
+}
+
+func verifyArcs(c *gc.C, fs *sparseFlowNetwork, mf *pr.MaxFlow, from pr.NodeID, expect [][]pr.Arc) {
+	var page = pr.PageInitial
+
+	for page != pr.PageEOF {
+		var arcs, next = fs.Arcs(mf, from, page)
+
+		c.Assert(len(expect), gc.Not(gc.Equals), 0)
+		c.Check(arcs, gc.DeepEquals, expect[0])
+		expect = expect[1:]
+		page = next
+	}
+	c.Check(expect, gc.HasLen, 0)
+}
+
+// noopNetwork is a pr.Network of size |nodes| with no Arcs.
+type noopNetwork struct{ *sparseFlowNetwork }
+
+func (s noopNetwork) Nodes() int                           { return s.sparseFlowNetwork.Nodes() }
+func (s noopNetwork) InitialHeight(id pr.NodeID) pr.Height { return 0 }
+func (s noopNetwork) Arcs(*pr.MaxFlow, pr.NodeID, pr.PageToken) ([]pr.Arc, pr.PageToken) {
+	return nil, pr.PageEOF
+}
+
+var _ = gc.Suite(&SparseSuite{})

--- a/allocator/sparse_push_relabel/push_relabel.go
+++ b/allocator/sparse_push_relabel/push_relabel.go
@@ -1,0 +1,452 @@
+package sparse_push_relabel
+
+import (
+	"container/heap"
+	"math"
+)
+
+type (
+	// Rate is the unit of flow velocity.
+	Rate int32
+	// Height of a node.
+	Height int32
+	// ID (index) of a node.
+	NodeID int32
+	// PageToken is used to traverse through a variable number of []Arc "pages"
+	// supplied by instances of the Network interface.
+	PageToken int32
+	// ID (index) of a Flow.
+	flowID int32
+)
+
+const (
+	// PageInitial is the first page of node []Arcs.
+	PageInitial PageToken = 0
+	// PageEOF indicates that no further pages of node []Arcs remain.
+	PageEOF PageToken = math.MaxInt32
+
+	// SourceID is the node from which all flow originates.
+	SourceID NodeID = 0
+	// SinkID is the node to which all flow is ultimately directed.
+	SinkID NodeID = 1
+
+	maxHeight Height = math.MaxInt32
+)
+
+// Arc is directed edge between a current node and another.
+type Arc struct {
+	To       NodeID // Node to which this Arc directs.
+	Capacity Rate   // Maximum flow Rate of this Arc.
+	// PushFront indicates whether a Flow associated with this Arc should be
+	// added at the head or tail of its linked lists. The primary implication
+	// is that Flows residuals are examined by discharge() in reverse order
+	// (eg, LIFO). By pushing to the front of the list, an Arc can express
+	// a preference that its residual should be considered only if no other
+	// residual will suffice.
+	PushFront bool
+}
+
+// Network is a flow network for which a maximum flow is desired. The
+// push/relabel solver inspects the Network as needed while executing the
+// algorithm. Arcs in particular may be called many times for a given NodeID
+// and PageToken.
+type Network interface {
+	// Nodes returns the number of nodes in the network,
+	// including the source & sink.
+	Nodes() int
+	// InitialHeight returns the initial Height of each node. This may be zero
+	// without impacting correctness, but for better performance should be the
+	// node's distance from the Sink.
+	InitialHeight(NodeID) Height
+	// Arcs returns the given page of node []Arcs, along with the next
+	// PageToken of Arcs which may be requested. The initial PageToken
+	// will be PageInitial, and PageEOF should be returned to indicate
+	// that no further pages remain.
+	Arcs(*MaxFlow, NodeID, PageToken) ([]Arc, PageToken)
+}
+
+// Adjacency represents a directed edge between two nodes.
+type Adjacency struct {
+	From, To NodeID
+}
+
+// Flow is a utilized graph Adjacency having a flow Rate.
+type Flow struct {
+	Adjacency
+	Rate Rate
+
+	fwdPrev, fwdNext flowID
+	revPrev, revNext flowID
+}
+
+type node struct {
+	height, nextHeight Height // Current, and upper-bound next Height of node.
+	excess             Rate   // Amount of node's flow excess.
+
+	fwdHead, fwdTail flowID // Head/tail of flows *from* this node.
+	revHead, revTail flowID // Head/tail of flows *to* this node.
+
+	dischargePage PageToken // Next PageToken for Arcs() of this node.
+	dischargeInd  int       // Next Arc index with that []Arc page.
+}
+
+// MaxFlow represents a maximum flow achieved over a Network.
+type MaxFlow struct {
+	nodes     []node
+	active    []NodeID // Nodes having non-zero excess, heaped on node height.
+	flows     []Flow   // All network Flows. flowIDs are indexes into this slice.
+	freeFlows []flowID // Free-list of |flows| for re-use.
+
+	// For the current node being discharge()'d, dischargeIdx is a dense index
+	// of a destination NodeID to the flowID which corresponds to the Flow from
+	// the current node to the indexed NodeID. Most entries will be zero,
+	// assuming a sparse utilization of available arcs. Each call to discharge()
+	// sets up and clears this index, which allows O(1) resolution to Flows.
+	dischargeIdx []flowID
+}
+
+// newMaxFlow returns a *MaxFlow initialized for the Network.
+func newMaxFlow(network Network) *MaxFlow {
+	var size = network.Nodes()
+
+	var mf = &MaxFlow{
+		nodes:        make([]node, size),
+		active:       []NodeID{SourceID},
+		flows:        []Flow{{}}, // Sentinel.
+		dischargeIdx: make([]flowID, size),
+	}
+
+	for i := range mf.nodes {
+		mf.nodes[i].nextHeight = maxHeight
+	}
+	mf.nodes[SourceID].excess = math.MaxInt32
+	mf.nodes[SourceID].height = Height(size)
+
+	for id := SinkID + 1; id != NodeID(size); id++ {
+		mf.nodes[id].height = network.InitialHeight(id)
+	}
+	return mf
+}
+
+// FindMaxFlow solves for the maximum flow of the given Network using a sparse
+// variant of the push/relabel algorithm.
+func FindMaxFlow(network Network) *MaxFlow {
+	var mf = newMaxFlow(network)
+	for {
+		if id, ok := mf.popActiveNode(); !ok {
+			return mf // All done.
+		} else {
+			mf.discharge(id, network)
+		}
+	}
+}
+
+// RelativeHeight returns the node Height delta, relative to the source node.
+// Depending on Network semantics, implementations may wish to use RelativeHeight
+// to condition capacities of returned []Arcs, for example by increasing capacity
+// if sufficient "pressure" has built up within the network.
+func (mf *MaxFlow) RelativeHeight(nid NodeID) Height {
+	return mf.nodes[nid].height - mf.nodes[SourceID].height
+}
+
+// Flows invokes the callback for each Flow of the given NodeID.
+func (mf *MaxFlow) Flows(nodeID NodeID, cb func(Flow)) {
+	for id := mf.nodes[nodeID].fwdHead; id != 0; id = mf.flows[id].fwdNext {
+		cb(mf.flows[id])
+	}
+}
+
+// discharge implements the push/relabel "node discharge" operation as it's
+// traditionally understood, by seeking to push excess flow of the node
+// along its arcs and residuals, relabeling the node as required, until no
+// excess node flow remains.
+func (mf *MaxFlow) discharge(nid NodeID, structure Network) {
+	var node = &mf.nodes[nid]
+
+	// Incrementally update |dischargeIdx| to provide O(1) lookups of NodeID to
+	// corresponding flowIDs. We'll undo our modifications upon return,
+	// restoring it to an initialized (zero) state. This is fast assuming our
+	// linked-list of forward flows is typically small.
+	for fid := node.fwdHead; fid != 0; fid = mf.flows[fid].fwdNext {
+		mf.dischargeIdx[mf.flows[fid].To] = fid
+	}
+	defer func() {
+		for fid := node.fwdHead; fid != 0; fid = mf.flows[fid].fwdNext {
+			mf.dischargeIdx[mf.flows[fid].To] = 0
+		}
+	}()
+
+	var (
+		arcs     []Arc
+		arcShift int
+		nextPage PageToken
+		fid      flowID
+	)
+
+	// Recover the page of |arcs| we stopped at on our last discharge. If we're
+	// instead walking residuals, restart |fid| from the list tail.
+	if node.dischargePage != PageEOF {
+		if arcs, nextPage = structure.Arcs(mf, nid, node.dischargePage); len(arcs) != 0 {
+			arcShift = int(nid) % len(arcs)
+		}
+	} else {
+		fid = node.revTail
+	}
+
+	for {
+
+		if node.dischargePage != PageEOF {
+			if node.dischargeInd != len(arcs) {
+				goto PushArc
+			} else {
+				goto NextPage
+			}
+		} else if fid != 0 {
+			goto PushResidual
+		} else {
+			goto Relabel
+		}
+
+	NextPage:
+
+		node.dischargePage, node.dischargeInd = nextPage, 0
+
+		if node.dischargePage != PageEOF {
+			if arcs, nextPage = structure.Arcs(mf, nid, node.dischargePage); len(arcs) != 0 {
+				arcShift = int(nid) % len(arcs)
+			}
+		} else {
+			fid = node.revTail // Walk backwards from the tail (LIFO order).
+		}
+		continue
+
+	PushArc:
+		{
+			// Shift the current arc by |nid| % len(arcs) to deterministically
+			// vary the Arc enumeration order of Nodes having common Arc sub-
+			// structure. This speeds the algorithm by avoiding having all such
+			// Nodes push along a single Arc during initial discharge.
+			// We hoist the modulo itself because profiling shows this integer
+			// division is otherwise a substantial part of discharge()'s runtime.
+			var a = node.dischargeInd + arcShift
+			if a >= len(arcs) {
+				a -= len(arcs) // Loop back around to walk [0, arcShift).
+			}
+			// Map Adjacency to a current flowID, or zero if there is no active Flow.
+			// Note that flowID 0 is a zero-valued sentinel Flow (ie Rate is 0).
+			fid = mf.dischargeIdx[arcs[a].To]
+
+			if mf.flows[fid].Rate >= arcs[a].Capacity || !mf.constrainHeight(node, arcs[a].To) {
+				node.dischargeInd++ // Cannot push.
+				continue
+			}
+
+			if fid == 0 {
+				// Adjacency is not yet tracked, and should be.
+				fid = mf.addFlow(Adjacency{From: nid, To: arcs[a].To}, arcs[a].PushFront)
+				mf.dischargeIdx[arcs[a].To] = fid
+			}
+
+			var delta = arcs[a].Capacity - mf.flows[fid].Rate
+			if delta > node.excess {
+				delta = node.excess
+			}
+			// Shift |delta| flow from this node to |arc.To|.
+			mf.flows[fid].Rate += delta
+			mf.updateExcess(nid, -delta)
+			mf.updateExcess(arcs[a].To, delta)
+
+			if node.excess == 0 {
+				return
+			}
+			// It's important we don't step |dischargeInd| until after the
+			// above excess check. If new excess is later pushed to this node,
+			// we want to consider remaining capacity of this Arc *first*.
+			node.dischargeInd++
+		}
+		continue
+
+	PushResidual:
+		{
+			// Walk residuals in reverse (LIFO) order, from list tail to head.
+			var nextFlow = mf.flows[fid].revPrev
+
+			if !mf.constrainHeight(node, mf.flows[fid].From) {
+				fid = nextFlow // Cannot push.
+				continue
+			}
+
+			var delta = mf.flows[fid].Rate
+			if delta > node.excess {
+				delta = node.excess
+			}
+			// Shift |delta| flow from this node back along the residual.
+			mf.flows[fid].Rate -= delta
+			mf.updateExcess(nid, -delta)
+			mf.updateExcess(mf.flows[fid].From, delta)
+
+			if mf.flows[fid].Rate == 0 {
+				// Flow no longer needs to be tracked. |fid| is invalidated,
+				// which is why we first retain |nextFlow|.
+				mf.removeFlow(fid)
+			}
+
+			if node.excess == 0 {
+				return
+			}
+			fid = nextFlow
+		}
+		continue
+
+	Relabel:
+
+		if nid == SourceID {
+			return // All done (we never relabel the source node).
+		}
+		node.height, node.nextHeight = node.nextHeight, maxHeight
+
+		// Reset to walk Arc pages.
+		node.dischargePage, nextPage, arcs = PageInitial, PageInitial, nil
+		continue
+	}
+}
+
+// constrainHeight returns true if |node|'s height is greater than |to|'s, a
+// constraint required by push/relabel in order for flow to be pushed from
+// |node| to |to|.
+//
+// If the constraint is not met, constrainHeight returns false and also updates
+// |node.nextHeight| to be lower-bound by |to|'s height+1, such that nextHeight
+// will express the lowest possible height at which |node| can be relabeled in
+// order to have constrainHeight() pass for at least one of the observed |to|'s.
+func (mf *MaxFlow) constrainHeight(node *node, to NodeID) bool {
+	if node.height <= mf.nodes[to].height {
+		if node.nextHeight > mf.nodes[to].height+1 {
+			node.nextHeight = mf.nodes[to].height + 1
+		}
+		return false
+	}
+	return true
+}
+
+// addFlow adds a new tracked zero-Rate Flow of the Adjacency. If |pushFront|,
+// then the Flow is added to the head of respective linked-lists, otherwise to
+// the tail.
+func (mf *MaxFlow) addFlow(adj Adjacency, pushFront bool) flowID {
+	var id flowID
+
+	// Grab an available ID from the free-list, or append a new Flow.
+	if l := len(mf.freeFlows); l != 0 {
+		id = mf.freeFlows[l-1]
+		mf.freeFlows = mf.freeFlows[:l-1]
+	} else {
+		id = flowID(len(mf.flows))
+		mf.flows = append(mf.flows, Flow{})
+	}
+
+	var flow = Flow{Adjacency: adj}
+	var from, to = &mf.nodes[adj.From], &mf.nodes[adj.To]
+
+	if pushFront {
+		if from.fwdHead == 0 {
+			from.fwdHead, from.fwdTail = id, id
+		} else {
+			mf.flows[from.fwdHead].fwdPrev = id
+			from.fwdHead, flow.fwdNext = id, from.fwdHead
+		}
+
+		if to.revHead == 0 {
+			to.revHead, to.revTail = id, id
+		} else {
+			mf.flows[to.revHead].revPrev = id
+			to.revHead, flow.revNext = id, to.revHead
+		}
+	} else {
+		if from.fwdTail == 0 {
+			from.fwdHead, from.fwdTail = id, id
+		} else {
+			mf.flows[from.fwdTail].fwdNext = id
+			flow.fwdPrev, from.fwdTail = from.fwdTail, id
+		}
+
+		if to.revTail == 0 {
+			to.revHead, to.revTail = id, id
+		} else {
+			mf.flows[to.revTail].revNext = id
+			flow.revPrev, to.revTail = to.revTail, id
+		}
+	}
+
+	mf.flows[id] = flow
+	return id
+}
+
+// removeFlow removes the Flow having flowID.
+func (mf *MaxFlow) removeFlow(id flowID) {
+	var flow = mf.flows[id]
+
+	if flow.fwdPrev == 0 {
+		mf.nodes[flow.From].fwdHead = flow.fwdNext
+	} else {
+		mf.flows[flow.fwdPrev].fwdNext = flow.fwdNext
+	}
+
+	if flow.fwdNext == 0 {
+		mf.nodes[flow.From].fwdTail = flow.fwdPrev
+	} else {
+		mf.flows[flow.fwdNext].fwdPrev = flow.fwdPrev
+	}
+
+	if flow.revPrev == 0 {
+		mf.nodes[flow.To].revHead = flow.revNext
+	} else {
+		mf.flows[flow.revPrev].revNext = flow.revNext
+	}
+
+	if flow.revNext == 0 {
+		mf.nodes[flow.To].revTail = flow.revPrev
+	} else {
+		mf.flows[flow.revNext].revPrev = flow.revPrev
+	}
+
+	mf.freeFlows = append(mf.freeFlows, id)
+	mf.flows[id] = Flow{}
+}
+
+// updateExcess of Node |id| with a positive or negative |delta|. If the node
+// excess was previously zero, it's marked as active for a future discharge.
+func (mf *MaxFlow) updateExcess(id NodeID, delta Rate) {
+	if mf.nodes[id].excess == 0 && id != SinkID {
+		heap.Push((*heightHeap)(mf), id)
+	}
+	mf.nodes[id].excess += delta
+}
+
+// popActiveNode returns the next node having excess flow in need of discharge.
+func (mf *MaxFlow) popActiveNode() (NodeID, bool) {
+	if len(mf.active) == 0 {
+		return 0, false
+	} else {
+		return heap.Pop((*heightHeap)(mf)).(NodeID), true
+	}
+}
+
+// heightHeap orders MaxFlow nodes on descending height.
+type heightHeap MaxFlow
+
+func (h *heightHeap) Len() int { return len(h.active) }
+func (h *heightHeap) Less(i, j int) bool {
+	return h.nodes[h.active[i]].height > h.nodes[h.active[j]].height
+}
+func (h *heightHeap) Swap(i, j int) {
+	h.active[i], h.active[j] = h.active[j], h.active[i]
+}
+func (h *heightHeap) Push(x interface{}) {
+	h.active = append(h.active, x.(NodeID))
+}
+func (h *heightHeap) Pop() interface{} {
+	var old, l = h.active, len(h.active)
+	var x = old[l-1]
+	h.active = old[0 : l-1]
+	return x
+}

--- a/allocator/sparse_push_relabel/push_relabel_test.go
+++ b/allocator/sparse_push_relabel/push_relabel_test.go
@@ -1,0 +1,536 @@
+package sparse_push_relabel
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleFixtureOne(t *testing.T) {
+	// Build the graph as described by the Push/Relabel Wikipedia page.
+	// There is only one valid maximum flow.
+	// https://en.wikipedia.org/wiki/Push%E2%80%93relabel_maximum_flow_algorithm#Example
+	const (
+		A = SinkID + 1
+		B = A + 1
+		C = B + 1
+		D = C + 1
+	)
+	var arcs = fixedArcs{
+		SourceID: {{
+			{To: A, Capacity: 15},
+			{To: C, Capacity: 4},
+		}},
+		A: {{{To: B, Capacity: 12}}},
+		B: {
+			// Arbitrarily split arcs across two pages (doesn't affect results).
+			{{To: C, Capacity: 3}},
+			{{To: SinkID, Capacity: 7}},
+		},
+		C: {{{To: D, Capacity: 10}}},
+		D: {{
+			{To: A, Capacity: 5},
+			{To: SinkID, Capacity: 10},
+		}},
+	}
+	var mf = FindMaxFlow(testNetwork{nodes: 6, arcsFn: arcs.fn})
+
+	assert.Equal(t, toMap(mf), map[Adjacency]Rate{
+		{From: A, To: B}:        10,
+		{From: B, To: C}:        3,
+		{From: B, To: SinkID}:   7,
+		{From: C, To: D}:        7,
+		{From: D, To: SinkID}:   7,
+		{From: SourceID, To: A}: 10,
+		{From: SourceID, To: C}: 4,
+	})
+}
+
+func TestSimpleFixtureTwo(t *testing.T) {
+	// Build the graph as described by the Maximum Flow Wikipedia page.
+	// There is only one valid maximum flow.
+	// https://en.wikipedia.org/wiki/Maximum_flow_problem
+	const (
+		O = SinkID + 1
+		P = O + 1
+		Q = P + 1
+		R = Q + 1
+	)
+	var arcs = fixedArcs{
+		SourceID: {{
+			{To: O, Capacity: 3},
+			{To: P, Capacity: 3},
+		}},
+		O: {{
+			{To: Q, Capacity: 3},
+			{To: P, Capacity: 2},
+		}},
+		P: {{{To: R, Capacity: 2}}},
+		Q: {{
+			{To: SinkID, Capacity: 2},
+			{To: R, Capacity: 4},
+		}},
+		R: {{{To: SinkID, Capacity: 3}}},
+	}
+	var mf = FindMaxFlow(testNetwork{nodes: 6, arcsFn: arcs.fn})
+
+	assert.Equal(t, toMap(mf), map[Adjacency]Rate{
+		{From: O, To: Q}:        3,
+		{From: P, To: R}:        2,
+		{From: Q, To: R}:        1,
+		{From: Q, To: SinkID}:   2,
+		{From: R, To: SinkID}:   3,
+		{From: SourceID, To: O}: 3,
+		{From: SourceID, To: P}: 2,
+	})
+}
+
+func TestCommonSubstructureFixture(t *testing.T) {
+	// Arcs fan out from the source to Nodes [2, 5]. Nodes [2, 5] are then fully
+	// connected with Nodes [6, 9], which then fan in to the sink. Arcs have
+	// plenty of capacity and multiple max-flows are possible.
+	var arcsFn = func(g *MaxFlow, id NodeID, token PageToken) ([]Arc, PageToken) {
+		if id == SourceID {
+			return []Arc{
+				{To: 2, Capacity: 2},
+				{To: 3, Capacity: 2},
+				{To: 4, Capacity: 2},
+				{To: 5, Capacity: 2},
+			}, PageEOF
+		} else if id >= 2 && id < 6 {
+			return []Arc{
+				{To: 6, Capacity: 100},
+				{To: 7, Capacity: 100},
+				{To: 8, Capacity: 100},
+				{To: 9, Capacity: 100},
+			}, PageEOF
+		} else {
+			return []Arc{{To: SinkID, Capacity: 100}}, PageEOF
+		}
+	}
+	var mf = FindMaxFlow(testNetwork{nodes: 11, arcsFn: arcsFn})
+
+	// Expect that the NodeID-based shift during arc selection results
+	// in flow which is balanced across arcs and Nodes.
+	assert.Equal(t, toMap(mf), map[Adjacency]Rate{
+		{From: SourceID, To: 2}: 2,
+		{From: SourceID, To: 3}: 2,
+		{From: SourceID, To: 4}: 2,
+		{From: SourceID, To: 5}: 2,
+
+		{From: 2, To: 8}: 2,
+		{From: 3, To: 9}: 2,
+		{From: 4, To: 6}: 2,
+		{From: 5, To: 7}: 2,
+
+		{From: 6, To: SinkID}: 2,
+		{From: 7, To: SinkID}: 2,
+		{From: 8, To: SinkID}: 2,
+		{From: 9, To: SinkID}: 2,
+	})
+
+	// Again. This time, express a preference for {From: id, To: id+2} adjacency
+	// via an initial []Arc page.
+	var arcsFn2 = func(g *MaxFlow, id NodeID, token PageToken) ([]Arc, PageToken) {
+		if id >= 2 && id < 6 && token == PageInitial {
+			return []Arc{{To: id + 4, Capacity: 1, PushFront: true}}, token + 1
+		}
+		return arcsFn(g, id, token)
+	}
+
+	mf = FindMaxFlow(testNetwork{nodes: 11, arcsFn: arcsFn2})
+
+	assert.Equal(t, toMap(mf), map[Adjacency]Rate{
+		{From: SourceID, To: 2}: 2,
+		{From: SourceID, To: 3}: 2,
+		{From: SourceID, To: 4}: 2,
+		{From: SourceID, To: 5}: 2,
+
+		// Preferred arc usages:
+		{From: 2, To: 6}: 1,
+		{From: 3, To: 7}: 1,
+		{From: 4, To: 8}: 1,
+		{From: 5, To: 9}: 1,
+
+		// Remainder usages:
+		{From: 2, To: 8}: 1,
+		{From: 3, To: 9}: 1,
+		{From: 4, To: 6}: 1,
+		{From: 5, To: 7}: 1,
+
+		{From: 6, To: SinkID}: 2,
+		{From: 7, To: SinkID}: 2,
+		{From: 8, To: SinkID}: 2,
+		{From: 9, To: SinkID}: 2,
+	})
+}
+
+func TestOverflowFixture(t *testing.T) {
+	// Arcs fan out from the source to Nodes [2, 4], which then fan in to node 5,
+	// which connects to the Sink. This 5 => sink arc fundamentally constrains
+	// graph throughput and causes residuals to be pushed back to the source.
+	var arcsFn = func(g *MaxFlow, id NodeID, token PageToken) ([]Arc, PageToken) {
+		if id == SourceID {
+			return []Arc{
+				{To: 2, Capacity: 1},
+				{To: 3, Capacity: 1},
+				{To: 4, Capacity: 1},
+			}, PageEOF
+		} else if id >= 2 && id < 5 {
+			return []Arc{
+				{To: 5, Capacity: 1},
+			}, PageEOF
+		}
+		return []Arc{{To: SinkID, Capacity: 1}}, PageEOF
+	}
+	var mf = FindMaxFlow(testNetwork{nodes: 11, arcsFn: arcsFn})
+
+	// Expect we find one of the valid max-flow solutions.
+	assert.Equal(t, toMap(mf), map[Adjacency]Rate{
+		{From: SourceID, To: 4}: 1,
+		{From: 4, To: 5}:        1,
+		{From: 5, To: SinkID}:   1,
+	})
+
+	// Again. This time, upon reaching a threshold height add additional
+	// capacity to the sink (though still not enough for all graph excess).
+	var arcsFn2 = func(g *MaxFlow, id NodeID, token PageToken) ([]Arc, PageToken) {
+		if id == 5 && g.nodes[5].height >= 12 {
+			return []Arc{{To: SinkID, Capacity: 2}}, PageEOF
+		}
+		return arcsFn(g, id, token)
+	}
+
+	mf = FindMaxFlow(testNetwork{nodes: 11, arcsFn: arcsFn2})
+
+	// Expect the new capacity is used.
+	assert.Equal(t, toMap(mf), map[Adjacency]Rate{
+		{From: SourceID, To: 2}: 1,
+		{From: SourceID, To: 4}: 1,
+		{From: 2, To: 5}:        1,
+		{From: 4, To: 5}:        1,
+		{From: 5, To: SinkID}:   2,
+	})
+}
+
+func TestNodeDischarge(t *testing.T) {
+	var mf = newMaxFlow(testNetwork{nodes: 6})
+	mf.nodes[2].height = 2
+	mf.nodes[3].height = 3
+	mf.nodes[4].height = 4
+	mf.nodes[5].height = mf.nodes[SourceID].height
+
+	// Add a residual from 5 => 2.
+	var fid = mf.addFlow(Adjacency{From: 5, To: 2}, false)
+	mf.flows[fid].Rate = 5
+	verifyFlows(t, mf, 5, []expectedFlow{{to: 2, rate: 5}})
+
+	// Add a residual from Source => 2.
+	fid = mf.addFlow(Adjacency{From: SourceID, To: 2}, true)
+	mf.flows[fid].Rate = 10
+	verifyFlows(t, mf, SourceID, []expectedFlow{{to: 2, rate: 10}})
+
+	var arcs = fixedArcs{
+		// Arbitrarily split arcs across two pages (doesn't affect results).
+		2: {
+			{{To: 4, Capacity: 1, PushFront: true}},
+			{
+				{To: SinkID, Capacity: 2},
+				{To: 3, Capacity: 3},
+			},
+		},
+	}
+	var s = testNetwork{arcsFn: arcs.fn}
+
+	// Expect our first discharge is to the sink.
+	mf.nodes[2].excess = 1
+	mf.discharge(2, s)
+
+	verifyFlows(t, mf, 2, []expectedFlow{{to: SinkID, rate: 1}}) // Flow added.
+	assert.Equal(t, mf.nodes[SinkID].excess, Rate(1))
+	assert.Equal(t, mf.nodes[2].nextHeight, Height(5)) // nodes[4].height + 1.
+
+	// Expect we can discharge again to the sink (we haven't stepped past the Arc).
+	mf.nodes[2].excess = 1
+	mf.discharge(2, s)
+
+	verifyFlows(t, mf, 2, []expectedFlow{{to: SinkID, rate: 2}}) // Updated.
+	assert.Equal(t, mf.nodes[SinkID].excess, Rate(2))
+	assert.Equal(t, mf.nodes[2].height, Height(2)) // No relabel occurred.
+
+	// Arc to Sink is saturated. We re-label to push to node 3.
+	mf.nodes[2].excess = 2
+	mf.discharge(2, s)
+
+	verifyFlows(t, mf, 2, []expectedFlow{
+		{to: SinkID, rate: 2},
+		{to: 3, rate: 2}, // Added.
+	})
+	assert.Equal(t, mf.nodes[3].excess, Rate(2))
+	assert.Equal(t, mf.nodes[2].height, Height(4))     // A tighter bound was found with node 3.
+	assert.Equal(t, mf.nodes[2].nextHeight, Height(5)) // nodes[4].height + 1.
+
+	// We're able to push once more to 3, then relabel before pushing to 4.
+	mf.nodes[2].excess = 2
+	mf.discharge(2, s)
+
+	verifyFlows(t, mf, 2, []expectedFlow{
+		{to: 4, rate: 1}, // Added at list front.
+		{to: SinkID, rate: 2},
+		{to: 3, rate: 3}, // Updated.
+	})
+	assert.Equal(t, mf.nodes[3].excess, Rate(3))
+	assert.Equal(t, mf.nodes[4].excess, Rate(1))
+	assert.Equal(t, mf.nodes[2].height, Height(5))
+	// Node 3 & the sink are saturated, and we just pushed to 4, so no |nextHeight| yet.
+	assert.Equal(t, mf.nodes[2].nextHeight, maxHeight)
+
+	// On next discharge we must relabel. We then push along the residual to 5.
+	// Though it was added first, the residual from Source used PushFront, and
+	// residuals are walked in reverse order.
+	mf.nodes[2].excess = 3
+	mf.discharge(2, s)
+
+	verifyFlows(t, mf, 5, []expectedFlow{{to: 2, rate: 2}}) // Was 5.
+	assert.Equal(t, mf.nodes[2].height, Height(7))
+	assert.Equal(t, mf.nodes[2].nextHeight, maxHeight)
+	assert.Equal(t, mf.nodes[2].dischargePage, PageEOF)
+
+	// Discharge again. We exhaust the residual to 5, and begin pushing
+	// along the residual to Source.
+	mf.nodes[2].excess = 3
+	mf.discharge(2, s)
+
+	verifyFlows(t, mf, 5, []expectedFlow{})                        // Removed.
+	verifyFlows(t, mf, SourceID, []expectedFlow{{to: 2, rate: 9}}) // Was 10.
+
+	mf.nodes[2].excess = 9
+	mf.discharge(2, s)
+
+	verifyFlows(t, mf, SourceID, []expectedFlow{}) // Removed.
+}
+
+func TestFlowTracking(t *testing.T) {
+	var mf = newMaxFlow(testNetwork{nodes: 5})
+
+	// Set initial free Flow fixtures.
+	mf.flows = append(mf.flows, Flow{}, Flow{}, Flow{})
+	mf.freeFlows = []flowID{2, 3, 1}
+
+	var id = mf.addFlow(Adjacency{SourceID, 2}, false)
+	assert.Equal(t, id, flowID(1))
+	id = mf.addFlow(Adjacency{SourceID, 4}, true)
+	assert.Equal(t, id, flowID(3))
+	id = mf.addFlow(Adjacency{SourceID, 3}, false)
+	assert.Equal(t, id, flowID(2))
+	id = mf.addFlow(Adjacency{2, 3}, true)
+	assert.Equal(t, id, flowID(4))
+	id = mf.addFlow(Adjacency{2, 4}, false)
+	assert.Equal(t, id, flowID(5))
+	id = mf.addFlow(Adjacency{3, 4}, false)
+	assert.Equal(t, id, flowID(6))
+
+	// Expect each Flow fixture is tracked and properly linked
+	// into per-node forward and reverse (residual) lists.
+	assert.Equal(t, mf.flows, []Flow{
+		{}, // Sentinel.
+		{
+			Adjacency: Adjacency{From: SourceID, To: 2},
+			fwdPrev:   3, fwdNext: 2, revPrev: 0, revNext: 0,
+		},
+		{
+			Adjacency: Adjacency{From: SourceID, To: 3},
+			fwdPrev:   1, fwdNext: 0, revPrev: 4, revNext: 0,
+		},
+		{
+			Adjacency: Adjacency{From: SourceID, To: 4},
+			fwdPrev:   0, fwdNext: 1, revPrev: 0, revNext: 5,
+		},
+		{
+			Adjacency: Adjacency{From: 2, To: 3},
+			fwdPrev:   0, fwdNext: 5, revPrev: 0, revNext: 2,
+		},
+		{
+			Adjacency: Adjacency{From: 2, To: 4},
+			fwdPrev:   4, fwdNext: 0, revPrev: 3, revNext: 6,
+		},
+		{
+			Adjacency: Adjacency{From: 3, To: 4},
+			fwdPrev:   0, fwdNext: 0, revPrev: 5, revNext: 0,
+		},
+	})
+
+	// Expect Nodes reflect the correct lists heads and tails.
+	assert.Equal(t, mf.nodes[SourceID].fwdHead, flowID(3))
+	assert.Equal(t, mf.nodes[SourceID].fwdTail, flowID(2))
+	assert.Equal(t, mf.nodes[SourceID].revHead, flowID(0))
+	assert.Equal(t, mf.nodes[SourceID].revTail, flowID(0))
+
+	assert.Equal(t, mf.nodes[2].fwdHead, flowID(4))
+	assert.Equal(t, mf.nodes[2].fwdTail, flowID(5))
+	assert.Equal(t, mf.nodes[2].revHead, flowID(1))
+	assert.Equal(t, mf.nodes[2].revTail, flowID(1))
+
+	assert.Equal(t, mf.nodes[4].fwdHead, flowID(0))
+	assert.Equal(t, mf.nodes[4].fwdTail, flowID(0))
+	assert.Equal(t, mf.nodes[4].revHead, flowID(3))
+	assert.Equal(t, mf.nodes[4].revTail, flowID(6))
+
+	// Begin incrementally removing flows. Expect links of remaining Flows
+	// are updated to reflect removals.
+	mf.removeFlow(6)
+	mf.removeFlow(1)
+
+	assert.Equal(t, mf.flows, []Flow{
+		{},
+		{},
+		{
+			Adjacency: Adjacency{From: SourceID, To: 3},
+			fwdPrev:   3, fwdNext: 0, revPrev: 4, revNext: 0,
+		},
+		{
+			Adjacency: Adjacency{From: SourceID, To: 4},
+			fwdPrev:   0, fwdNext: 2, revPrev: 0, revNext: 5,
+		},
+		{
+			Adjacency: Adjacency{From: 2, To: 3},
+			fwdPrev:   0, fwdNext: 5, revPrev: 0, revNext: 2,
+		},
+		{
+			Adjacency: Adjacency{From: 2, To: 4},
+			fwdPrev:   4, fwdNext: 0, revPrev: 3, revNext: 0,
+		},
+		{},
+	})
+
+	assert.Equal(t, mf.nodes[2].revHead, flowID(0)) // Removed (was 1).
+	assert.Equal(t, mf.nodes[2].revTail, flowID(0)) // Removed (was 1).
+
+	assert.Equal(t, mf.nodes[4].revHead, flowID(3))
+	assert.Equal(t, mf.nodes[4].revTail, flowID(5)) // Updated (was 6).
+
+	mf.removeFlow(3)
+	mf.removeFlow(5)
+
+	assert.Equal(t, mf.flows, []Flow{
+		{},
+		{},
+		{
+			Adjacency: Adjacency{From: SourceID, To: 3},
+			fwdPrev:   0, fwdNext: 0, revPrev: 4, revNext: 0,
+		},
+		{},
+		{
+			Adjacency: Adjacency{From: 2, To: 3},
+			fwdPrev:   0, fwdNext: 0, revPrev: 0, revNext: 2,
+		},
+		{},
+		{},
+	})
+
+	assert.Equal(t, mf.nodes[SourceID].fwdHead, flowID(2)) // Updated (was 3).
+	assert.Equal(t, mf.nodes[SourceID].fwdTail, flowID(2))
+
+	assert.Equal(t, mf.nodes[2].fwdHead, flowID(4))
+	assert.Equal(t, mf.nodes[2].fwdTail, flowID(4)) // Updated (was 5).
+
+	assert.Equal(t, mf.nodes[4].revHead, flowID(0)) // Removed (was 3).
+	assert.Equal(t, mf.nodes[4].revTail, flowID(0)) // Removed (was 5).
+
+	mf.removeFlow(4)
+	mf.removeFlow(2)
+
+	assert.Equal(t, mf.flows, make([]Flow, 7))
+
+	// Expect after removing all Flows, Nodes are in their initial state.
+	for i := range mf.nodes {
+		assert.Equal(t, mf.nodes[i].fwdHead, flowID(0))
+		assert.Equal(t, mf.nodes[i].fwdTail, flowID(0))
+		assert.Equal(t, mf.nodes[i].revHead, flowID(0))
+		assert.Equal(t, mf.nodes[i].revTail, flowID(0))
+	}
+	// All prior flowIDs are on the free-list.
+	assert.Equal(t, mf.freeFlows, []flowID{6, 1, 3, 5, 4, 2})
+}
+
+func TestActiveTrackingOnHeight(t *testing.T) {
+	var mf = newMaxFlow(testNetwork{nodes: 5})
+	mf.nodes[2].height = 2
+	mf.nodes[3].height = 3
+	mf.nodes[4].height = 4
+
+	assert.Equal(t, mf.active, []NodeID{SourceID})
+	mf.updateExcess(2, 5)
+	assert.Equal(t, mf.active, []NodeID{SourceID, 2})
+
+	mf.updateExcess(2, -3)
+	mf.updateExcess(4, 2)
+	mf.updateExcess(SinkID, 3)
+	mf.updateExcess(3, 2)
+	mf.updateExcess(4, 1)
+	mf.updateExcess(3, -1)
+
+	for _, expect := range []struct {
+		id     NodeID
+		excess Rate
+	}{
+		{SourceID, math.MaxInt32},
+		{4, 3},
+		{3, 1},
+		{2, 2},
+	} {
+		var id, ok = mf.popActiveNode()
+		assert.True(t, ok)
+		assert.Equal(t, id, expect.id)
+		assert.Equal(t, mf.nodes[id].excess, expect.excess)
+	}
+	var _, ok = mf.popActiveNode()
+	assert.False(t, ok)
+}
+
+func toMap(g *MaxFlow) map[Adjacency]Rate {
+	var out = make(map[Adjacency]Rate)
+
+	for _, f := range g.flows {
+		if f.Rate != 0 {
+			out[f.Adjacency] = f.Rate
+		}
+	}
+	return out
+}
+
+type expectedFlow struct {
+	to   NodeID
+	rate Rate
+}
+
+func verifyFlows(t *testing.T, mf *MaxFlow, nid NodeID, expect []expectedFlow) {
+	mf.Flows(nid, func(flow Flow) {
+		assert.Equal(t, flow.To, expect[0].to)
+		assert.Equal(t, flow.Rate, expect[0].rate)
+		expect = expect[1:]
+	})
+	assert.Equal(t, expect, []expectedFlow{})
+}
+
+type testNetwork struct {
+	nodes  int
+	arcsFn func(g *MaxFlow, id NodeID, token PageToken) ([]Arc, PageToken)
+}
+
+func (s testNetwork) Nodes() int                     { return s.nodes }
+func (s testNetwork) InitialHeight(id NodeID) Height { return 0 }
+func (s testNetwork) Arcs(g *MaxFlow, id NodeID, token PageToken) ([]Arc, PageToken) {
+	return s.arcsFn(g, id, token)
+}
+
+type fixedArcs map[NodeID][][]Arc
+
+func (f fixedArcs) fn(g *MaxFlow, id NodeID, token PageToken) ([]Arc, PageToken) {
+	if pages, token := f[id][token], token+1; token == PageToken(len(f[id])) {
+		return pages, PageEOF
+	} else {
+		return pages, token
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.8.0
+	github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612
 	github.com/sirupsen/logrus v1.0.5
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/afero v1.2.2
@@ -37,7 +38,6 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
 	google.golang.org/api v0.7.0
-	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610
 	google.golang.org/grpc v1.22.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,7 @@ github.com/prometheus/client_golang v0.8.0 h1:1921Yw9Gc3iSc4VQh3PIoOqgPCZS7G/4xQ
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612 h1:13pIdM2tpaDi4OVe24fgoIS7ZTqMt0QI+bwQsX5hq+g=
 github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/common v0.0.0-20180518154759-7600349dcfe1 h1:osmNoEW2SCW3L7EX0km2LYM8HKpNWRiouxjE3XHkyGc=
 github.com/prometheus/common v0.0.0-20180518154759-7600349dcfe1/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180612222113-7d6f385de8be h1:MoyXp/VjXUwM0GyDcdwT7Ubea2gxOSHpPaFo3qV+Y2A=

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -7,16 +7,20 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // Keys for gazette metrics.
 const (
-	CommittedBytesTotalKey              = "gazette_committed_bytes_total"
-	CommitsTotalKey                     = "gazette_commits_total"
-	RecoveryLogRecoveredBytesTotalKey   = "gazette_recoverylog_recovered_bytes_total"
-	StoreRequestsTotalKey               = "gazette_store_requests_total"
-	StorePersistedBytesTotalKey         = "gazette_store_persisted_bytes_total"
+	AllocatorAssignmentAddedTotalKey    = "gazette_allocator_assignment_added_total"
+	AllocatorAssignmentPackedTotalKey   = "gazette_allocator_assignment_packed_total"
+	AllocatorAssignmentRemovedTotalKey  = "gazette_allocator_assignment_removed_total"
 	AllocatorConvergeTotalKey           = "gazette_allocator_converge_total"
-	AllocatorMembersKey                 = "gazette_allocator_members"
-	AllocatorItemsKey                   = "gazette_allocator_items"
-	AllocatorDesiredReplicationSlotsKey = "gazette_allocator_desired_replication_slots"
+	AllocatorMaxFlowRuntimeSecondsKey   = "gazette_allocator_max_flow_runtime_seconds"
+	AllocatorNumItemSlotsKey            = "gazette_allocator_desired_replication_slots"
+	AllocatorNumItemsKey                = "gazette_allocator_items"
+	AllocatorNumMembersKey              = "gazette_allocator_members"
+	CommitsTotalKey                     = "gazette_commits_total"
+	CommittedBytesTotalKey              = "gazette_committed_bytes_total"
 	JournalServerResponseTimeSecondsKey = "gazette_journal_server_response_time_seconds"
+	RecoveryLogRecoveredBytesTotalKey   = "gazette_recoverylog_recovered_bytes_total"
+	StorePersistedBytesTotalKey         = "gazette_store_persisted_bytes_total"
+	StoreRequestsTotalKey               = "gazette_store_requests_total"
 
 	Fail = "fail"
 	Ok   = "ok"
@@ -24,6 +28,38 @@ const (
 
 // Collectors for gazette metrics.
 var (
+	AllocatorAssignmentAddedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: AllocatorAssignmentAddedTotalKey,
+		Help: "Cumulative number of item / member assignments added by the allocator.",
+	})
+	AllocatorAssignmentPackedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: AllocatorAssignmentPackedTotalKey,
+		Help: "Cumulative number of item / member assignments packed by the allocator.",
+	})
+	AllocatorAssignmentRemovedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: AllocatorAssignmentRemovedTotalKey,
+		Help: "Cumulative number of item / member assignments removed by the allocator.",
+	})
+	AllocatorConvergeTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: AllocatorConvergeTotalKey,
+		Help: "Cumulative number of converge iterations.",
+	})
+	AllocatorMaxFlowRuntimeSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: AllocatorMaxFlowRuntimeSecondsKey,
+		Help: "Duration required to re-solve for maximum assignment.",
+	})
+	AllocatorNumItemSlots = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: AllocatorNumItemSlotsKey,
+		Help: "Number of desired item replication slots summed across all items.",
+	})
+	AllocatorNumItems = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: AllocatorNumItemsKey,
+		Help: "Number of items known to the allocator.",
+	})
+	AllocatorNumMembers = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: AllocatorNumMembersKey,
+		Help: "Number of members known to the allocator.",
+	})
 	CommittedBytesTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: CommittedBytesTotalKey,
 		Help: "Cumulative number of bytes committed to journals.",
@@ -44,22 +80,6 @@ var (
 		Name: StorePersistedBytesTotalKey,
 		Help: "Cumulative number of bytes persisted to fragment stores.",
 	}, []string{"provider"})
-	AllocatorConvergeTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: AllocatorConvergeTotalKey,
-		Help: "Cumulative number of converge iterations.",
-	})
-	AllocatorMembers = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: AllocatorMembersKey,
-		Help: "Number of members known to the allocator.",
-	})
-	AllocatorItems = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: AllocatorItemsKey,
-		Help: "Number of items known to the allocator.",
-	})
-	AllocatorDesiredReplicationSlots = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: AllocatorDesiredReplicationSlotsKey,
-		Help: "Number of desired replicaiton slots summed across all items.",
-	})
 	JournalServerResponseTimeSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: JournalServerResponseTimeSecondsKey,
 		Help: "Response time of JournalServer.Append.",
@@ -69,16 +89,19 @@ var (
 // GazetteBrokerCollectors lists collectors used by the gazette broker.
 func GazetteBrokerCollectors() []prometheus.Collector {
 	return []prometheus.Collector{
-		CommittedBytesTotal,
-		CommitsTotal,
-		RecoveryLogRecoveredBytesTotal,
-		StoreRequestTotal,
-		StorePersistedBytesTotal,
+		AllocatorAssignmentAddedTotal,
+		AllocatorAssignmentPackedTotal,
+		AllocatorAssignmentRemovedTotal,
 		AllocatorConvergeTotal,
-		AllocatorMembers,
-		AllocatorItems,
-		AllocatorDesiredReplicationSlots,
+		AllocatorMaxFlowRuntimeSeconds,
+		AllocatorNumItemSlots,
+		AllocatorNumItems,
+		AllocatorNumMembers,
+		CommitsTotal,
+		CommittedBytesTotal,
 		JournalServerResponseTimeSeconds,
+		StorePersistedBytesTotal,
+		StoreRequestTotal,
 	}
 }
 


### PR DESCRIPTION
Hey gang,

This is a fundamental rework of the maximum-flow solver within the allocator. There were a few goals with this work, which I believe have been met:

 * Achieve a more natural balancing of items across members and zones ("fair share" balancing), without relaxing desired solver constraints (at least 2 zones per item).

All constraints (2+ zones; member limits) and goals (uniform zone utilization & fair-share member balancing) are now directly captured within the flow-network architecture / max-flow solver. The "zone scaling factors" heuristic and zone sizing hacks are removed.

 * Capable of scaling to 100K+ allocated items efficiently.

The `simulated-deploy` benchmark shows the new solver is about an order of magnitude faster on small graphs (eg N=5K is about 30ms vs 700ms-1s). For large graphs, the sparse solver remains useable (eg at N=100K with 20K members, the sparse solver runs in 2-10s on a 2015 macbook), where the dense solver DoS's itself due to its memory consumption.

This subject matter can be more than a little mind-bending, so let me know if you want to set up some time to talk through the implementation.

Issue #79

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/201)
<!-- Reviewable:end -->
