### PR TITLE
fragment: List uses ParseContentName instead of ParseContentPath

### DIFF
--- a/broker/fragment/doc.go
+++ b/broker/fragment/doc.go
@@ -1,8 +1,17 @@
-// Package fragment is concerned with the mapping of journal offsets to
-// protocol.Fragments, to corresponding local or remote journal content. It
-// provides implementation for:
-//  * Interacting with remote fragment stores.
-//  * Indexing local and remote Fragments (see Index).
-//  * The construction of new Fragments from a replication stream (see Spool).
-//  * The persisting of constructed Fragments to remote stores (see Persister).
+// Package fragment is a broker-only package concerned with the mapping of journal offsets to
+// protocol.Fragments, and from there to corresponding local or remote journal content.
+//
+// It implements file-like operations over the FragmentStore schemes supported
+// by Gazette, such as listing, opening, signing, persisting, and removing fragments.
+// See FileStoreConfig, S3StoreConfig, and GSStoreConfig for further configuration
+// of store operations.
+//
+// The package implements a Fragment wrapper type which composes a protocol.Fragment
+// with an open file descriptor, and an Index over local or remote Fragments which maps
+// a journal offset to a best-covering Fragment.
+//
+// Spool is a Fragment which is in the process of being constructed from an ongoing
+// broker Replicate RPC. It is the transactional "memory" of brokers which are
+// participating in the replication of a journal. Once closed, or "rolled", a Spool
+// Fragment is persisted to its configured FragmentStore by a Persister.
 package fragment

--- a/broker/fragment/persister.go
+++ b/broker/fragment/persister.go
@@ -15,6 +15,7 @@ const (
 	persistInterval = time.Minute
 )
 
+// Persister asynchronously persists completed Fragments to their backing pb.FragmentStore.
 type Persister struct {
 	qA, qB, qC []Spool
 	mu         sync.Mutex

--- a/broker/fragment/stores.go
+++ b/broker/fragment/stores.go
@@ -142,19 +142,32 @@ func instrumentStoreOp(provider, op string, err error) {
 	}
 }
 
-// rewriterCfg holds a find/replace pair, often populated by parseStoreArgs()
-// and provides a convenience function to rewrite the given path.
+// RewriterConfig rewrites the path under which journal fragments are stored
+// by finding and replacing a portion of the journal's name in the final
+// constructed path. Its use is uncommon and not recommended, but it can help
+// in the implementation of new journal naming taxonomies which don't disrupt
+// journal fragments that are already written.
 //
-// It is meant to be embedded by other backend store configs.
-type rewriterCfg struct {
-	Find, Replace string
+//      var cfg = RewriterConfig{
+//          Replace: "/old-path/page-views/
+//          Find:    "/bar/v1/page-views/",
+//      }
+//      // Remaps journal name => fragment store URL:
+//      //  "/foo/bar/v1/page-views/part-000" => "s3://my-bucket/foo/old-path/page-views/part-000" // Matched.
+//      //  "/foo/bar/v2/page-views/part-000" => "s3://my-bucket/foo/bar/v2/page-views/part-000"   // Not matched.
+//
+type RewriterConfig struct {
+	// Find is the string to replace in the unmodified journal name.
+	Find string
+	// Replace is the string with which Find is replaced in the constructed store path.
+	Replace string
 }
 
 // rewritePath replace the first occurrence of the find string with the replace
 // string in journal path |j| and appends it to the fragment store path |s|,
 // effectively rewriting the default Journal path. If find is empty or not
 // found, the original |j| is appended.
-func (cfg rewriterCfg) rewritePath(s, j string) string {
+func (cfg RewriterConfig) rewritePath(s, j string) string {
 	if cfg.Find == "" {
 		return s + j
 	}

--- a/broker/fragment/stores_test.go
+++ b/broker/fragment/stores_test.go
@@ -1,0 +1,183 @@
+package fragment
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gazette.dev/core/broker/client"
+	"go.gazette.dev/core/broker/codecs"
+	pb "go.gazette.dev/core/broker/protocol"
+)
+
+// How to test individual FragmentStore implementations:
+//
+// S3:
+// 1) Set minio credentials & config to AWS application default credentials (~/.aws):
+// $ cp kustomize/test/bases/environment/minio_credentials ~/.aws/credentials
+// $ cp kustomize/test/bases/environment/minio_config ~/.aws/config
+//
+// 2) Test, enabling SDK config loading, and replacing Minio endpoint with correct service IP. Eg:
+// $ AWS_SDK_LOAD_CONFIG=1 go test -v ./broker/fragment -test.run TestStoreInteractions \
+//   -store "s3://examples/frag-test/?find=rwFind&replace=rwReplace&profile=minio&endpoint=http%3A%2F%2F10.152.183.246%3A9000"
+//
+// GCS:
+// 1) Write credentials under ~/.config/gcloud/application_default_credentials.json
+//
+// 2) Test:
+// $ go test -v ./broker/fragment -test.run TestStoreInteractions \
+//   -store "gs://bucket-that-i-own/frag-test/?find=rwFind&replace=rwReplace"
+
+var storeEndpoint = flag.String("store",
+	"file:///?find=rwFind&replace=rwReplace",
+	"store endpoint under test")
+
+func TestStoreInteractions(t *testing.T) {
+	var fs = pb.FragmentStore(*storeEndpoint)
+	require.NoError(t, fs.Validate())
+
+	var dir, err = ioutil.TempDir("", "stores_test")
+	require.NoError(t, err)
+
+	defer client.InstallFileTransport(dir)()
+	defer os.RemoveAll(dir)
+
+	defer func(s string) { FileSystemStoreRoot = s }(FileSystemStoreRoot)
+	FileSystemStoreRoot = dir
+
+	// Begin by persisting a number of fragment fixtures.
+	// Persist twice, to exercise handling where the fragment exists.
+	var ctx = context.Background()
+	for _, s := range buildSpoolFixtures(t) {
+		s.BackingStore = fs
+		require.NoError(t, Persist(ctx, s))
+		require.NoError(t, Persist(ctx, s))
+	}
+
+	// List fragments of both journals.
+	var fooFrags []pb.Fragment
+	require.NoError(t, List(ctx, fs, tstRWFoo,
+		func(f pb.Fragment) { fooFrags = append(fooFrags, f) }))
+
+	var barFrags []pb.Fragment
+	require.NoError(t, List(ctx, fs, tstBar,
+		func(f pb.Fragment) { barFrags = append(barFrags, f) }))
+
+	require.Len(t, fooFrags, 3)
+	require.Len(t, barFrags, 2)
+
+	// Expect we can also list fragments of tstRWFoo directly, post-rewrite.
+	var fooFragsPostRW []pb.Fragment
+	require.NoError(t, List(ctx, fs, "tst/rwReplace/foo",
+		func(f pb.Fragment) { fooFragsPostRW = append(fooFragsPostRW, f) }))
+
+	require.Len(t, fooFragsPostRW, 3)
+
+	// Fragments reflect their correct listed journals.
+	assert.Equal(t, tstRWFoo, fooFrags[0].Journal)
+	assert.Equal(t, tstBar, barFrags[0].Journal)
+	assert.Equal(t, pb.Journal("tst/rwReplace/foo"), fooFragsPostRW[0].Journal)
+
+	// We can open and read expected fragment content.
+	assert.Equal(t, tstRWFooData[1], readFrag(t, fooFrags[1]))
+	assert.Equal(t, tstBarData[0], readFrag(t, barFrags[0]))
+
+	// We can create a signed URL and GET it.
+	getURL, err := SignGetURL(fooFrags[0], time.Minute)
+	require.NoError(t, err)
+	fr, err := client.OpenFragmentURL(ctx, fooFrags[0], 0, getURL)
+	require.NoError(t, err)
+	b, err := ioutil.ReadAll(fr)
+	require.NoError(t, err)
+	require.NoError(t, fr.Close())
+	assert.Equal(t, tstRWFooData[0], string(b))
+
+	// We can remove all fragments.
+	for _, f := range fooFrags {
+		require.NoError(t, Remove(ctx, f))
+	}
+	for _, f := range barFrags {
+		require.NoError(t, Remove(ctx, f))
+	}
+
+	// We no longer see them in listings.
+	require.NoError(t, List(ctx, fs, tstRWFoo,
+		func(f pb.Fragment) { panic("no fragments, not called") }))
+	require.NoError(t, List(ctx, fs, tstBar,
+		func(f pb.Fragment) { panic("not called") }))
+}
+
+func readFrag(t *testing.T, f pb.Fragment) string {
+	var rc, err = Open(context.Background(), f)
+	require.NoError(t, err)
+	dec, err := codecs.NewCodecReader(rc, f.CompressionCodec)
+	require.NoError(t, err)
+	b, err := ioutil.ReadAll(dec)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	return string(b)
+}
+
+func buildSpoolFixtures(t *testing.T) []Spool {
+	var runSeq = func(s *Spool, vals []string, primary bool) {
+		for _, v := range vals {
+			require.NoError(t, s.applyContent(&pb.ReplicateRequest{
+				Content: []byte(v),
+			}))
+
+			// Commit.
+			var p = s.Next()
+			require.Equal(t, pb.Status_OK, s.applyCommit(&pb.ReplicateRequest{
+				Proposal:  &p,
+				Registers: new(pb.LabelSet),
+			}, primary).Status)
+
+			// Roll spool.
+			p.Begin = p.End
+			p.Sum = pb.SHA1Sum{}
+
+			require.Equal(t, pb.Status_OK, s.applyCommit(&pb.ReplicateRequest{
+				Proposal:  &p,
+				Registers: new(pb.LabelSet),
+			}, primary).Status)
+
+		}
+	}
+	var (
+		obv testSpoolObserver
+		s1  = NewSpool(tstRWFoo, &obv)
+		s2  = NewSpool(tstBar, &obv)
+	)
+	s1.CompressionCodec = pb.CompressionCodec_SNAPPY
+	s2.CompressionCodec = pb.CompressionCodec_GZIP
+
+	runSeq(&s1, tstRWFooData, true)
+	runSeq(&s2, tstBarData, false)
+
+	require.Len(t, obv.completes, len(tstRWFooData)+len(tstBarData))
+	return obv.completes
+}
+
+var (
+	tstRWFoo     pb.Journal = "tst/rwFind/foo"
+	tstRWFooData            = []string{
+		`Great things are done by a series of small things
+			brought together. -Van Gogh`,
+		"and other",
+		"data",
+	}
+
+	tstBar     pb.Journal = "tst/bar"
+	tstBarData            = []string{
+		`I am a part of all that I have met;
+			Yet all experience is an arch wherethro'
+			Gleams that untravell'd world whose margin fades
+			For ever and forever when I move. -Tennyson`,
+		"second commit",
+	}
+)

--- a/broker/protocol/fragment_extensions.go
+++ b/broker/protocol/fragment_extensions.go
@@ -35,12 +35,7 @@ func (m *Fragment) Validate() error {
 	return nil
 }
 
-// ParseContentPath parses a ContentPath into a Fragment, or returns an error.
-func ParseContentPath(p string) (Fragment, error) {
-	return ParseContentName(Journal(path.Dir(p)), path.Base(p))
-}
-
-// ParseContentName parses a Journal and ContentName into a Fragment, or returns an error.
+// ParseContentName parses a ContentName into a Fragment of the Journal, or returns an error.
 func ParseContentName(journal Journal, name string) (Fragment, error) {
 	var f Fragment
 

--- a/broker/protocol/fragment_extensions_test.go
+++ b/broker/protocol/fragment_extensions_test.go
@@ -64,7 +64,7 @@ func (s *FragmentSuite) TestValidationCases(c *gc.C) {
 }
 
 func (s *FragmentSuite) TestParsingSuccessCases(c *gc.C) {
-	var f, err = ParseContentPath("a/journal/" +
+	var f, err = ParseContentName("a/journal",
 		"00000000499602d2-7fffffffffffffff-0102030405060708090a0b0c0d0e0f1011121314.gz")
 
 	c.Check(err, gc.IsNil)
@@ -77,7 +77,7 @@ func (s *FragmentSuite) TestParsingSuccessCases(c *gc.C) {
 	})
 
 	// Again, but with no file extension (indicating Content-Encoding compression).
-	f, err = ParseContentPath("a/journal/" +
+	f, err = ParseContentName("a/journal",
 		"00000000499602d2-7fffffffffffffff-0102030405060708090a0b0c0d0e0f1011121314")
 
 	c.Check(err, gc.IsNil)
@@ -90,7 +90,7 @@ func (s *FragmentSuite) TestParsingSuccessCases(c *gc.C) {
 	})
 
 	// Empty spool (begin == end, and zero checksum).
-	f, err = ParseContentPath("a/journal/" +
+	f, err = ParseContentName("a/journal",
 		"00000000499602d2-00000000499602d2-0000000000000000000000000000000000000000.raw")
 	c.Assert(err, gc.IsNil)
 	c.Assert(f, gc.DeepEquals, Fragment{
@@ -103,32 +103,32 @@ func (s *FragmentSuite) TestParsingSuccessCases(c *gc.C) {
 }
 
 func (s *FragmentSuite) TestParsingErrorCases(c *gc.C) {
-	var _, err = ParseContentPath("a/journal/" +
+	var _, err = ParseContentName("a/journal",
 		"00000000499602d2-7fffffffffffffff-0102030405060708090a0b0c0d0e0f1011121314-extra.gz")
 	c.Check(err, gc.ErrorMatches, "wrong Fragment format: .*")
 
-	_, err = ParseContentPath("a/journal/" +
+	_, err = ParseContentName("a/journal",
 		"00000000499602XX-7fffffffffffffff-0102030405060708090a0b0c0d0e0f1011121314.gz")
 	c.Check(err, gc.ErrorMatches, "Begin: strconv.ParseInt: .*")
 
-	_, err = ParseContentPath("a/journal/" +
+	_, err = ParseContentName("a/journal",
 		"00000000499602d2-7fffffffffffffXX-0102030405060708090a0b0c0d0e0f1011121314.gz")
 	c.Check(err, gc.ErrorMatches, "End: strconv.ParseInt: .*")
 
-	_, err = ParseContentPath("a/journal/" +
+	_, err = ParseContentName("a/journal",
 		"00000000499602d2-7fffffffffffffff-0102030405060708090a0b0c0d0e0f10111213XX.gz")
 	c.Check(err, gc.ErrorMatches, "Sum: encoding/hex: .*")
 
-	_, err = ParseContentPath("a/journal/" +
+	_, err = ParseContentName("a/journal",
 		"00000000499602d2-7fffffffffffffff-0102030405060708090a0b0c0d0e0f10111213.gz")
 	c.Check(err, gc.ErrorMatches, "invalid SHA1Sum length: .*")
 
-	_, err = ParseContentPath("a/journal/" +
+	_, err = ParseContentName("a/journal",
 		"00000000499602d2-7fffffffffffffff-0102030405060708090a0b0c0d0e0f1011121314.XXX")
 	c.Check(err, gc.ErrorMatches, "unrecognized compression extension: .XXX")
 
 	// Expect we also Validate the parsed Fragment before returning.
-	_, err = ParseContentPath("a/journal/" +
+	_, err = ParseContentName("a/journal",
 		"7fffffffffffffff-00000000499602d2-0102030405060708090a0b0c0d0e0f1011121314.gz")
 	c.Check(err, gc.ErrorMatches, "expected Begin <= End .*")
 }

--- a/broker/protocol/fragment_store.go
+++ b/broker/protocol/fragment_store.go
@@ -9,18 +9,18 @@ import (
 // FragmentStores "root" remote storage locations of fragments, their path
 // component must end in a trailing slash.
 //
-// FragmentStore implementations may support additional configuration which
-// can be declared via URL query arguments. The meaning of these query
-// arguments and values are specific to the store in question; consult the
-// store implementation to see properties available for configuration.
-//
-// Currently supported schemes are `gs` for Google Cloud Storage, `s3` for
-// Amazon S3, and `file` for a local file-system / NFS mount. Eg:
+// Currently supported schemes are "gs" for Google Cloud Storage, "s3" for
+// Amazon S3, and "file" for a local file-system / NFS mount. Eg:
 //
 //  * s3://bucket-name/a/sub-path/?profile=a-shared-credentials-profile
 //  * gs://bucket-name/a/sub-path/?
 //  * file:///a/local/volume/mount
 //
+// FragmentStore implementations may support additional configuration which
+// can be declared via URL query arguments. The meaning of these query
+// arguments and values are specific to the store in question; consult
+// FileStoreConfig, S3StoreConfig, and GSStoreConfig of the fragment
+// package for details of available configuration.
 type FragmentStore string
 
 // Validate returns an error if the FragmentStore is not well-formed.

--- a/broker/protocol/rpc_extensions_test.go
+++ b/broker/protocol/rpc_extensions_test.go
@@ -41,7 +41,8 @@ func (s *RPCSuite) TestReadRequestValidation(c *gc.C) {
 }
 
 func (s *RPCSuite) TestReadResponseValidationCases(c *gc.C) {
-	var frag, _ = ParseContentPath("a/journal/00000000499602d2-000000008bd03835-0102030405060708090a0b0c0d0e0f1011121314.sz")
+	var frag, _ = ParseContentName("a/journal",
+		"00000000499602d2-000000008bd03835-0102030405060708090a0b0c0d0e0f1011121314.sz")
 	frag.Journal = "/bad/name"
 
 	var resp = ReadResponse{


### PR DESCRIPTION
ParseContentPath doesn't properly deal with name rewrites. Remove it
altogether, as it's fundamentally broken.

Also, expose S3StoreConfig, FileStoreConfig, and GSStoreConfig and
improve their respective godocs.

Issue #223

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/224)
<!-- Reviewable:end -->
