### PR TITLE
consumer: return descriptive error when a nil state is passed into NewJSONFileStore

### DIFF
--- a/consumer/store_json_file.go
+++ b/consumer/store_json_file.go
@@ -33,6 +33,9 @@ var _ Store = &JSONFileStore{} // JSONFileStore is-a Store.
 // of the Store's state, which is decoded into, encoded from, and retained
 // as JSONFileState.State.
 func NewJSONFileStore(rec *recoverylog.Recorder, state interface{}) (*JSONFileStore, error) {
+	if state == nil {
+		return nil, errors.New("state must not be nil")
+	}
 	var store = &JSONFileStore{
 		State:    state,
 		fs:       recoverylog.RecordedAferoFS{Recorder: rec, Fs: afero.NewOsFs()},


### PR DESCRIPTION
Return a more descriptive error if a `nil` `state` into `NewJSONFileStore`.

Didn't add/modify tests as the change is pretty trivial. LMK if you think otherwise.