### PR TITLE
gazctl apply: interpret revision -1 as 'don't care'

### DIFF
--- a/broker/list_apply_api.go
+++ b/broker/list_apply_api.go
@@ -111,7 +111,12 @@ func (svc *Service) Apply(ctx context.Context, req *pb.ApplyRequest) (resp *pb.A
 			key = allocator.ItemKey(s.KS, change.Delete.String())
 			ops = append(ops, clientv3.OpDelete(key))
 		}
-		cmp = append(cmp, clientv3.Compare(clientv3.ModRevision(key), "=", change.ExpectModRevision))
+
+		// Allow caller to explicitly ignore revision comparison
+		// by passing a value of -1 for revision.
+		if change.ExpectModRevision != -1 {
+			cmp = append(cmp, clientv3.Compare(clientv3.ModRevision(key), "=", change.ExpectModRevision))
+		}
 	}
 
 	var txnResp clientv3.OpResponse

--- a/broker/list_apply_api_test.go
+++ b/broker/list_apply_api_test.go
@@ -202,6 +202,22 @@ func TestApplyCases(t *testing.T) {
 			},
 		})).Status)
 
+	// Case: Update with explicit revision of -1 succeeds.
+	assert.Equal(t, pb.Status_OK,
+		must(broker.client().Apply(ctx, &pb.ApplyRequest{
+			Changes: []pb.ApplyRequest_Change{
+				{Upsert: &specB, ExpectModRevision: -1},
+			},
+		})).Status)
+
+	// Case: Deletion with explicit revision of -1 succeeds.
+	assert.Equal(t, pb.Status_OK,
+		must(broker.client().Apply(ctx, &pb.ApplyRequest{
+			Changes: []pb.ApplyRequest_Change{
+				{Delete: "journal/B", ExpectModRevision: -1},
+			},
+		})).Status)
+
 	// Case: Invalid requests fail with an error.
 	var _, err = broker.client().Apply(ctx, &pb.ApplyRequest{
 		Changes: []pb.ApplyRequest_Change{{Delete: "invalid journal name"}},

--- a/broker/protocol/rpc_extensions.go
+++ b/broker/protocol/rpc_extensions.go
@@ -325,13 +325,13 @@ func (m *ApplyRequest_Change) Validate() error {
 		} else if err := m.Upsert.Validate(); err != nil {
 			return ExtendContext(err, "Upsert")
 		} else if m.ExpectModRevision < 0 && (m.ExpectModRevision != -1) {
-			return NewValidationError("invalid ExpectModRevision (%d; expected >= 0)", m.ExpectModRevision)
+			return NewValidationError("invalid ExpectModRevision (%d; expected >= 0 or -1)", m.ExpectModRevision)
 		}
 	} else if m.Delete != "" {
 		if err := m.Delete.Validate(); err != nil {
 			return ExtendContext(err, "Delete")
 		} else if m.ExpectModRevision <= 0 && (m.ExpectModRevision != -1){
-			return NewValidationError("invalid ExpectModRevision (%d; expected > 0)", m.ExpectModRevision)
+			return NewValidationError("invalid ExpectModRevision (%d; expected > 0 or -1)", m.ExpectModRevision)
 		}
 	} else {
 		return NewValidationError("neither Upsert nor Delete are set (expected exactly one)")

--- a/broker/protocol/rpc_extensions.go
+++ b/broker/protocol/rpc_extensions.go
@@ -324,13 +324,13 @@ func (m *ApplyRequest_Change) Validate() error {
 			return NewValidationError("both Upsert and Delete are set (expected exactly one)")
 		} else if err := m.Upsert.Validate(); err != nil {
 			return ExtendContext(err, "Upsert")
-		} else if m.ExpectModRevision < 0 {
+		} else if m.ExpectModRevision < 0 && (m.ExpectModRevision != -1) {
 			return NewValidationError("invalid ExpectModRevision (%d; expected >= 0)", m.ExpectModRevision)
 		}
 	} else if m.Delete != "" {
 		if err := m.Delete.Validate(); err != nil {
 			return ExtendContext(err, "Delete")
-		} else if m.ExpectModRevision <= 0 {
+		} else if m.ExpectModRevision <= 0 && (m.ExpectModRevision != -1){
 			return NewValidationError("invalid ExpectModRevision (%d; expected > 0)", m.ExpectModRevision)
 		}
 	} else {

--- a/broker/protocol/rpc_extensions_test.go
+++ b/broker/protocol/rpc_extensions_test.go
@@ -377,11 +377,11 @@ func (s *RPCSuite) TestApplyRequestValidationCases(c *gc.C) {
 			Retention:        time.Hour,
 		},
 	}
-	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[0\]: invalid ExpectModRevision \(-2; expected >= 0\)`)
+	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[0\]: invalid ExpectModRevision \(-2; expected >= 0 or -1\)`)
 	req.Changes[0].ExpectModRevision = 0
 	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[1\].Delete: not a valid token \(.*\)`)
 	req.Changes[1].Delete = "a/journal"
-	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[1\]: invalid ExpectModRevision \(0; expected > 0\)`)
+	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[1\]: invalid ExpectModRevision \(0; expected > 0 or -1\)`)
 	req.Changes[1].ExpectModRevision = 1
 	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[2\]: neither Upsert nor Delete are set \(expected exactly one\)`)
 	req.Changes[2].Delete = "other/journal"

--- a/broker/protocol/rpc_extensions_test.go
+++ b/broker/protocol/rpc_extensions_test.go
@@ -349,7 +349,7 @@ func (s *RPCSuite) TestApplyRequestValidationCases(c *gc.C) {
 	var req = ApplyRequest{
 		Changes: []ApplyRequest_Change{
 			{
-				ExpectModRevision: -1,
+				ExpectModRevision: -2,
 				Upsert:            &JournalSpec{Name: "a/journal"},
 				Delete:            "a/journal",
 			},
@@ -377,7 +377,7 @@ func (s *RPCSuite) TestApplyRequestValidationCases(c *gc.C) {
 			Retention:        time.Hour,
 		},
 	}
-	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[0\]: invalid ExpectModRevision \(-1; expected >= 0\)`)
+	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[0\]: invalid ExpectModRevision \(-2; expected >= 0\)`)
 	req.Changes[0].ExpectModRevision = 0
 	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[1\].Delete: not a valid token \(.*\)`)
 	req.Changes[1].Delete = "a/journal"

--- a/cmd/gazctl/journals_apply.go
+++ b/cmd/gazctl/journals_apply.go
@@ -32,6 +32,9 @@ and will fail the entire apply operation if any have since been updated. A
 common operational pattern is to list, edit, and re-apply a collection of
 JournalSpecs; this check ensures concurrent modifications are caught.
 
+You may explicitly inform the broker to apply your JournalSpecs regardless of the
+current state of specifications in Etcd by passing in a revision value of -1.
+
 JournalSpecs may be created by setting "revision" to zero or omitting altogether.
 
 JournalSpecs may be deleted by setting field "delete" to true on individual

--- a/cmd/gazctl/journals_apply.go
+++ b/cmd/gazctl/journals_apply.go
@@ -34,6 +34,8 @@ JournalSpecs; this check ensures concurrent modifications are caught.
 
 You may explicitly inform the broker to apply your JournalSpecs regardless of the
 current state of specifications in Etcd by passing in a revision value of -1.
+This commonly done when operators keep JournalSpecs in version control as their
+source of truth.
 
 JournalSpecs may be created by setting "revision" to zero or omitting altogether.
 

--- a/cmd/gazctl/shards_apply.go
+++ b/cmd/gazctl/shards_apply.go
@@ -26,6 +26,11 @@ ShardSpec is correct, and will fail the entire apply operation if any have since
 been updated. A common operational pattern is to list, edit, and re-apply a
 collection of ShardSpecs; this check ensures concurrent modifications are caught.
 
+You may explicitly inform the broker to apply your ShardSpecs regardless of the
+current state of specifications in Etcd by passing in a revision value of -1.
+This commonly done when operators keep ShardSpecs in version control as their
+source of truth.
+
 ShardSpecs may be created by setting "revision" to zero or omitting it altogether.
 
 ShardSpecs may be deleted by setting their field "delete" to true.

--- a/consumer/protocol/rpc_extensions.go
+++ b/consumer/protocol/rpc_extensions.go
@@ -92,14 +92,14 @@ func (m *ApplyRequest_Change) Validate() error {
 			return pb.NewValidationError("both Upsert and Delete are set (expected exactly one)")
 		} else if err := m.Upsert.Validate(); err != nil {
 			return pb.ExtendContext(err, "Upsert")
-		} else if m.ExpectModRevision < 0 {
-			return pb.NewValidationError("invalid ExpectModRevision (%d; expected >= 0)", m.ExpectModRevision)
+		} else if m.ExpectModRevision < 0 && (m.ExpectModRevision != -1) {
+			return pb.NewValidationError("invalid ExpectModRevision (%d; expected >= 0 or -1)", m.ExpectModRevision)
 		}
 	} else if m.Delete != "" {
 		if err := m.Delete.Validate(); err != nil {
 			return pb.ExtendContext(err, "Delete")
-		} else if m.ExpectModRevision <= 0 {
-			return pb.NewValidationError("invalid ExpectModRevision (%d; expected > 0)", m.ExpectModRevision)
+		} else if m.ExpectModRevision <= 0 && (m.ExpectModRevision != -1) {
+			return pb.NewValidationError("invalid ExpectModRevision (%d; expected > 0 or -1)", m.ExpectModRevision)
 		}
 	} else {
 		return pb.NewValidationError("neither Upsert nor Delete are set (expected exactly one)")

--- a/consumer/protocol/rpc_extensions_test.go
+++ b/consumer/protocol/rpc_extensions_test.go
@@ -97,7 +97,7 @@ func (s *RPCSuite) TestApplyRequestValidationCases(c *gc.C) {
 	var req = ApplyRequest{
 		Changes: []ApplyRequest_Change{
 			{
-				ExpectModRevision: -1,
+				ExpectModRevision: -2,
 				Upsert: &ShardSpec{
 					Id:                "invalid id",
 					Sources:           []ShardSpec_Source{{Journal: "a/journal"}},
@@ -121,11 +121,11 @@ func (s *RPCSuite) TestApplyRequestValidationCases(c *gc.C) {
 	req.Changes[0].Delete = ""
 	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[0\].Upsert.Id: not a valid token \(invalid id\)`)
 	req.Changes[0].Upsert.Id = "a-valid-id"
-	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[0\]: invalid ExpectModRevision \(-1; expected >= 0\)`)
+	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[0\]: invalid ExpectModRevision \(-2; expected >= 0 or -1\)`)
 	req.Changes[0].ExpectModRevision = 0
 	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[1\].Delete: not a valid token \(another invalid id\)`)
 	req.Changes[1].Delete = "other-valid-id"
-	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[1\]: invalid ExpectModRevision \(0; expected > 0\)`)
+	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[1\]: invalid ExpectModRevision \(0; expected > 0 or -1\)`)
 	req.Changes[1].ExpectModRevision = 1
 	c.Check(req.Validate(), gc.ErrorMatches, `Changes\[2\]: neither Upsert nor Delete are set \(expected exactly one\)`)
 	req.Changes[2].Delete = "yet-another-valid-id"

--- a/consumer/shard_api.go
+++ b/consumer/shard_api.go
@@ -120,7 +120,11 @@ func (srv *Service) Apply(ctx context.Context, req *pc.ApplyRequest) (*pc.ApplyR
 			key = allocator.ItemKey(s.KS, changes.Delete.String())
 			ops = append(ops, clientv3.OpDelete(key))
 		}
-		cmp = append(cmp, clientv3.Compare(clientv3.ModRevision(key), "=", changes.ExpectModRevision))
+		// Allow caller to explicitly ignore revision comparison
+		// by passing a value of -1 for revision.
+		if changes.ExpectModRevision != -1 {
+			cmp = append(cmp, clientv3.Compare(clientv3.ModRevision(key), "=", changes.ExpectModRevision))
+		}
 	}
 
 	var txnResp, err = srv.Etcd.Do(ctx, clientv3.OpTxn(cmp, ops, nil))

--- a/consumer/shard_api_test.go
+++ b/consumer/shard_api_test.go
@@ -175,6 +175,20 @@ func TestAPIApplyCases(t *testing.T) {
 		},
 	}).Status)
 
+	// Case: Update with explicit revision of -1 succeeds.
+	assert.Equal(t, pc.Status_OK, apply(&pc.ApplyRequest{
+		Changes: []pc.ApplyRequest_Change{
+			{Upsert: specB, ExpectModRevision: -1},
+		},
+	}).Status)
+
+	// Case: Deletion with explicit revision of -1 succeeds.
+	assert.Equal(t, pc.Status_OK, apply(&pc.ApplyRequest{
+		Changes: []pc.ApplyRequest_Change{
+			{Delete: shardB, ExpectModRevision: -1},
+		},
+	}).Status)
+
 	// Case: Invalid requests fail with an error.
 	var _, err = tf.service.Apply(context.Background(), &pc.ApplyRequest{
 		Changes: []pc.ApplyRequest_Change{{Delete: "invalid shard id"}},

--- a/docs/_static/cmd-gazctl-journals-apply.txt
+++ b/docs/_static/cmd-gazctl-journals-apply.txt
@@ -15,6 +15,11 @@ and will fail the entire apply operation if any have since been updated. A
 common operational pattern is to list, edit, and re-apply a collection of
 JournalSpecs; this check ensures concurrent modifications are caught.
 
+You may explicitly inform the broker to apply your JournalSpecs regardless of the
+current state of specifications in Etcd by passing in a revision value of -1.
+This commonly done when operators keep JournalSpecs in version control as their
+source of truth.
+
 JournalSpecs may be created by setting "revision" to zero or omitting altogether.
 
 JournalSpecs may be deleted by setting field "delete" to true on individual

--- a/docs/_static/cmd-gazctl-journals-prune.txt
+++ b/docs/_static/cmd-gazctl-journals-prune.txt
@@ -3,7 +3,9 @@ Usage:
 
 Deletes fragments across all configured fragment stores of matching journals that are older than the configured retention.
 
-There is a caveat when pruning journals. For a given journal, there could be multiple fragments covering the same offset. These fragments contain identical data at a given offset, but the brokers are tracking only the largest fragment, i.e. the fragment that covers the largest span of offsets. As a result, the prune command will delete only this tracked fragment, leaving the smaller fragments untouched. As a workaround, operators can wait for the fragment listing to refresh and prune the journals again.
+There is a caveat when pruning journals. For a given journal, there could be multiple fragments covering the same offset. These fragments contain identical data at a given offset, but
+the brokers are tracking only the largest fragment, i.e. the fragment that covers the largest span of offsets. As a result, the prune command will delete only this tracked fragment,
+leaving the smaller fragments untouched. As a workaround, operators can wait for the fragment listing to refresh and prune the journals again.
 
 Use --selector to supply a LabelSelector to select journals to prune.
 See "journals list --help" for details and examples.

--- a/docs/_static/cmd-gazctl-journals-prune.txt
+++ b/docs/_static/cmd-gazctl-journals-prune.txt
@@ -3,9 +3,7 @@ Usage:
 
 Deletes fragments across all configured fragment stores of matching journals that are older than the configured retention.
 
-There is a caveat when pruning journals. For a given journal, there could be multiple fragments covering the same offset. These fragments contain identical data at a given offset, but
-the brokers are tracking only the largest fragment, i.e. the fragment that covers the largest span of offsets. As a result, the prune command will delete only this tracked fragment,
-leaving the smaller fragments untouched. As a workaround, operators can wait for the fragment listing to refresh and prune the journals again.
+There is a caveat when pruning journals. For a given journal, there could be multiple fragments covering the same offset. These fragments contain identical data at a given offset, but the brokers are tracking only the largest fragment, i.e. the fragment that covers the largest span of offsets. As a result, the prune command will delete only this tracked fragment, leaving the smaller fragments untouched. As a workaround, operators can wait for the fragment listing to refresh and prune the journals again.
 
 Use --selector to supply a LabelSelector to select journals to prune.
 See "journals list --help" for details and examples.

--- a/docs/_static/cmd-gazctl-shards-apply.txt
+++ b/docs/_static/cmd-gazctl-shards-apply.txt
@@ -9,6 +9,11 @@ ShardSpec is correct, and will fail the entire apply operation if any have since
 been updated. A common operational pattern is to list, edit, and re-apply a
 collection of ShardSpecs; this check ensures concurrent modifications are caught.
 
+You may explicitly inform the broker to apply your ShardSpecs regardless of the
+current state of specifications in Etcd by passing in a revision value of -1.
+This commonly done when operators keep ShardSpecs in version control as their
+source of truth.
+
 ShardSpecs may be created by setting "revision" to zero or omitting it altogether.
 
 ShardSpecs may be deleted by setting their field "delete" to true.


### PR DESCRIPTION
This change addresses #244 which allows explicit ignoring of revision mismatches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/247)
<!-- Reviewable:end -->
