### PR TITLE
allocator: refactor ItemValue.IsConsistent into a free function callback

### DIFF
--- a/allocator/alloc_state_test.go
+++ b/allocator/alloc_state_test.go
@@ -20,10 +20,10 @@ func (s *AllocStateSuite) TestExtractOverFixture(c *gc.C) {
 	// Examine multiple states derived from the KeySpace fixture, each
 	// pivoted around a different Member key.
 	var states = []*State{
-		NewObservedState(ks, MemberKey(ks, "us-west", "baz")),
-		NewObservedState(ks, MemberKey(ks, "us-east", "bar")),
-		NewObservedState(ks, MemberKey(ks, "us-east", "foo")),
-		NewObservedState(ks, MemberKey(ks, "does-not", "exist")),
+		NewObservedState(ks, MemberKey(ks, "us-west", "baz"), isConsistent),
+		NewObservedState(ks, MemberKey(ks, "us-east", "bar"), isConsistent),
+		NewObservedState(ks, MemberKey(ks, "us-east", "foo"), isConsistent),
+		NewObservedState(ks, MemberKey(ks, "does-not", "exist"), isConsistent),
 	}
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
@@ -86,9 +86,9 @@ func (s *AllocStateSuite) TestLeaderSelection(c *gc.C) {
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
 	var states = []*State{
-		NewObservedState(ks, MemberKey(ks, "us-east", "bar")),
-		NewObservedState(ks, MemberKey(ks, "us-east", "foo")),
-		NewObservedState(ks, MemberKey(ks, "us-west", "baz")),
+		NewObservedState(ks, MemberKey(ks, "us-east", "bar"), isConsistent),
+		NewObservedState(ks, MemberKey(ks, "us-east", "foo"), isConsistent),
+		NewObservedState(ks, MemberKey(ks, "us-west", "baz"), isConsistent),
 	}
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
@@ -113,8 +113,8 @@ func (s *AllocStateSuite) TestExitCondition(c *gc.C) {
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
 	var states = []*State{
-		NewObservedState(ks, MemberKey(ks, "us-east", "foo")),
-		NewObservedState(ks, MemberKey(ks, "us-east", "allowed-to-exit")),
+		NewObservedState(ks, MemberKey(ks, "us-east", "foo"), isConsistent),
+		NewObservedState(ks, MemberKey(ks, "us-east", "allowed-to-exit"), isConsistent),
 	}
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
@@ -134,7 +134,7 @@ func (s *AllocStateSuite) TestLoadRatio(c *gc.C) {
 	defer etcdtest.Cleanup()
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
-	var state = NewObservedState(ks, MemberKey(ks, "us-east", "foo"))
+	var state = NewObservedState(ks, MemberKey(ks, "us-east", "foo"), isConsistent)
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
 	// Verify expected load ratios, computed using these counts. Note Assignments are:

--- a/allocator/allocator_key_space.go
+++ b/allocator/allocator_key_space.go
@@ -40,11 +40,6 @@ type MemberValue interface {
 type ItemValue interface {
 	// DesiredReplication for this Item.
 	DesiredReplication() int
-	// IsConsistent returns true if the |assignment| is consistent. Some
-	// implementations may determine consistency within the context of
-	// the full set of item assignments, so |allAssignments| is also
-	// provided (of which |assignment| is a member).
-	IsConsistent(assignment keyspace.KeyValue, allAssignments keyspace.KeyValues) bool
 }
 
 // AssignmentValue is a user-defined Assignment representation.

--- a/allocator/allocator_key_space_test.go
+++ b/allocator/allocator_key_space_test.go
@@ -349,7 +349,8 @@ func (d testAllocDecoder) DecodeAssignment(itemID, zone, suffix string, slot int
 type testItem struct{ R int }
 
 func (i testItem) DesiredReplication() int { return i.R }
-func (i testItem) IsConsistent(assignment keyspace.KeyValue, allAssignments keyspace.KeyValues) bool {
+
+func isConsistent(_ Item, assignment keyspace.KeyValue, allAssignments keyspace.KeyValues) bool {
 	return assignment.Decoded.(Assignment).AssignmentValue.(testAssignment).consistent
 }
 

--- a/allocator/allocator_test.go
+++ b/allocator/allocator_test.go
@@ -58,7 +58,7 @@ func (s *AllocatorSuite) TestConvergeFixtureCases(c *gc.C) {
 	buildAllocKeySpaceFixture(c, ctx, client)
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
-	var as = NewObservedState(ks, MemberKey(ks, "us-east", "foo"))
+	var as = NewObservedState(ks, MemberKey(ks, "us-east", "foo"), isConsistent)
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
 	// Tweak the fixture to associate a lease with Member us-east/foo

--- a/allocator/announce_test.go
+++ b/allocator/announce_test.go
@@ -74,7 +74,7 @@ func (s *AnnounceSuite) TestBasicSessionStart(c *gc.C) {
 		ks    = NewAllocatorKeySpace("/root", testAllocDecoder{})
 		sigCh = make(chan os.Signal)
 		spec  = &testMember{R: 10}
-		state = NewObservedState(ks, MemberKey(ks, "a", "member"))
+		state = NewObservedState(ks, MemberKey(ks, "a", "member"), isConsistent)
 
 		args = SessionArgs{
 			Etcd:     etcd,

--- a/allocator/benchmark_test.go
+++ b/allocator/benchmark_test.go
@@ -38,7 +38,7 @@ func benchmarkSimulatedDeploy(b *testing.B) {
 
 	var ctx, _ = context.WithCancel(context.Background())
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
-	var state = NewObservedState(ks, MemberKey(ks, "zone-b", "leader"))
+	var state = NewObservedState(ks, MemberKey(ks, "zone-b", "leader"), isConsistent)
 
 	var NItems = b.N
 

--- a/allocator/flow_network_test.go
+++ b/allocator/flow_network_test.go
@@ -67,7 +67,7 @@ func (s *FlowNetworkSuite) TestFlowOverSimpleFixture(c *gc.C) {
 	buildAllocKeySpaceFixture(c, ctx, client)
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
-	var state = NewObservedState(ks, MemberKey(ks, "us-west", "baz"))
+	var state = NewObservedState(ks, MemberKey(ks, "us-west", "baz"), isConsistent)
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
 	var fn flowNetwork

--- a/allocator/item_state.go
+++ b/allocator/item_state.go
@@ -88,7 +88,7 @@ func (s *itemState) constrainRemovals() {
 	// Determine the current number of consistent item Assignments.
 	var n int
 	for _, a := range s.current {
-		if item.IsConsistent(a, s.current) {
+		if s.global.IsConsistent(item, a, s.current) {
 			n += 1
 		}
 	}
@@ -97,7 +97,7 @@ func (s *itemState) constrainRemovals() {
 	var limit int
 
 	for r := item.DesiredReplication(); n >= r && limit != len(s.remove); limit++ {
-		if c := item.IsConsistent(s.remove[limit], s.current); c && n == r {
+		if c := s.global.IsConsistent(item, s.remove[limit], s.current); c && n == r {
 			break // We cannot remove this assignment without breaking n >= r.
 		} else if c {
 			n -= 1
@@ -137,7 +137,7 @@ func (s *itemState) constrainReorders() {
 	}{index: -1}
 
 	for i := range s.reorder {
-		var c = item.IsConsistent(s.reorder[i], s.current)
+		var c = s.global.IsConsistent(item, s.reorder[i], s.current)
 		var r = s.global.memberLoadRatio(s.reorder[i], s.global.MemberPrimaryCount)
 
 		if primary.index == -1 ||

--- a/allocator/item_state_test.go
+++ b/allocator/item_state_test.go
@@ -413,7 +413,7 @@ func buildItemStateFixture(c *gc.C, fixture map[string]string) (*keyspace.KeySpa
 	}
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
-	var as = NewObservedState(ks, MemberKey(ks, "zone", "member-1"))
+	var as = NewObservedState(ks, MemberKey(ks, "zone", "member-1"), isConsistent)
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
 	return ks, &itemState{global: as}

--- a/allocator/scenarios_test.go
+++ b/allocator/scenarios_test.go
@@ -951,7 +951,7 @@ func serveUntilIdle(c *gc.C, ctx context.Context, client *clientv3.Client, ks *k
 		clientv3.WithSort(clientv3.SortByCreateRevision, clientv3.SortAscend))
 	c.Assert(err, gc.IsNil)
 
-	var state = NewObservedState(ks, string(resp.Kvs[0].Key))
+	var state = NewObservedState(ks, string(resp.Kvs[0].Key), isConsistent)
 
 	var result int
 	ctx, cancel := context.WithCancel(ctx)

--- a/allocator/sparse_flow_network_test.go
+++ b/allocator/sparse_flow_network_test.go
@@ -17,7 +17,7 @@ func (s *SparseSuite) TestOverKeySpaceFixture(c *gc.C) {
 	buildAllocKeySpaceFixture(c, ctx, client)
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
-	var state = NewObservedState(ks, MemberKey(ks, "us-west", "baz"))
+	var state = NewObservedState(ks, MemberKey(ks, "us-west", "baz"), isConsistent)
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
 	const (
@@ -148,7 +148,7 @@ func (s *SparseSuite) TestMemberScalingOverflow(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 	}
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
-	var state = NewObservedState(ks, MemberKey(ks, "A", "one"))
+	var state = NewObservedState(ks, MemberKey(ks, "A", "one"), isConsistent)
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
 	const (
@@ -234,7 +234,7 @@ func (s *SparseSuite) TestZonePlacementOverflow(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 	}
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
-	var state = NewObservedState(ks, MemberKey(ks, "A", "one"))
+	var state = NewObservedState(ks, MemberKey(ks, "A", "one"), isConsistent)
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
 	const (
@@ -305,7 +305,7 @@ func (s *SparseSuite) TestZoneBalancing(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 	}
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
-	var state = NewObservedState(ks, MemberKey(ks, "us-west", "baz"))
+	var state = NewObservedState(ks, MemberKey(ks, "us-west", "baz"), isConsistent)
 	c.Check(ks.Load(ctx, client, 0), gc.IsNil)
 
 	const (

--- a/broker/append_fsm.go
+++ b/broker/append_fsm.go
@@ -318,7 +318,7 @@ func (b *appendFSM) onUpdateAssignments() {
 
 	// Do the Etcd-advertised values of our resolved journal assignments match
 	// the current journal Route (indicating the journal is consistent)?
-	if pb.JournalRouteMatchesAssignments(b.resolved.Route, b.resolved.assignments) {
+	if JournalRouteMatchesAssignments(b.resolved.Route, b.resolved.assignments) {
 		b.state = stateAwaitDesiredReplicas
 		return
 	}

--- a/broker/key_space_test.go
+++ b/broker/key_space_test.go
@@ -1,0 +1,42 @@
+package broker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.gazette.dev/core/allocator"
+	pb "go.gazette.dev/core/broker/protocol"
+	"go.gazette.dev/core/keyspace"
+)
+
+func TestJournalConsistencyCases(t *testing.T) {
+	var routes [3]pb.Route
+	var assignments keyspace.KeyValues
+
+	for i := range routes {
+		routes[i].Primary = 0
+		routes[i].Members = []pb.ProcessSpec_ID{
+			{Zone: "zone/a", Suffix: "member/1"},
+			{Zone: "zone/a", Suffix: "member/3"},
+			{Zone: "zone/b", Suffix: "member/2"},
+		}
+		assignments = append(assignments, keyspace.KeyValue{
+			Decoded: allocator.Assignment{
+				AssignmentValue: &routes[i],
+				MemberSuffix:    routes[0].Members[i].Suffix,
+				MemberZone:      routes[0].Members[i].Zone,
+				Slot:            i,
+			},
+		})
+	}
+
+	// Case: all assignments match.
+	assert.True(t, JournalIsConsistent(allocator.Item{}, keyspace.KeyValue{}, assignments))
+	// Case: vary indicated primary of Route.
+	routes[0].Primary = 1
+	assert.False(t, JournalIsConsistent(allocator.Item{}, keyspace.KeyValue{}, assignments))
+	routes[0].Primary = 0
+	// Case: vary members.
+	routes[1].Members = append(routes[1].Members, pb.ProcessSpec_ID{Zone: "zone/b", Suffix: "member/4"})
+	assert.False(t, JournalIsConsistent(allocator.Item{}, keyspace.KeyValue{}, assignments))
+}

--- a/broker/protocol/journal_spec_extensions.go
+++ b/broker/protocol/journal_spec_extensions.go
@@ -8,8 +8,6 @@ import (
 	"text/template"
 	"time"
 
-	"go.gazette.dev/core/allocator"
-	"go.gazette.dev/core/keyspace"
 	"go.gazette.dev/core/labels"
 )
 
@@ -204,27 +202,6 @@ func (m *JournalSpec) MarshalString() string {
 // DesiredReplication returns the configured Replication of the spec. It
 // implements allocator.ItemValue.
 func (m *JournalSpec) DesiredReplication() int { return int(m.Replication) }
-
-// IsConsistent returns true if the Route stored under each of |assignments|
-// agrees with the Route implied by the |assignments| keys. It implements
-// allocator.ItemValue.
-func (m *JournalSpec) IsConsistent(_ keyspace.KeyValue, assignments keyspace.KeyValues) bool {
-	var rt Route
-	rt.Init(assignments)
-
-	return JournalRouteMatchesAssignments(rt, assignments)
-}
-
-// JournalRouteMatchesAssignments returns true iff the Route is equivalent to the
-// Route marshaled with each of the journal's |assignments|.
-func JournalRouteMatchesAssignments(rt Route, assignments keyspace.KeyValues) bool {
-	for _, a := range assignments {
-		if !rt.Equivalent(a.Decoded.(allocator.Assignment).AssignmentValue.(*Route)) {
-			return false
-		}
-	}
-	return len(rt.Members) == len(assignments)
-}
 
 // UnionJournalSpecs returns a JournalSpec combining all non-zero-valued fields
 // across |a| and |b|. Where both |a| and |b| provide a non-zero value for

--- a/broker/test_support_test.go
+++ b/broker/test_support_test.go
@@ -51,11 +51,11 @@ func newTestBroker(t assert.TestingT, etcd *clientv3.Client, id pb.ProcessSpec_I
 		tasks: task.NewGroup(context.Background()),
 		ks:    NewKeySpace("/broker.test"),
 	}
+	var state = allocator.NewObservedState(bk.ks,
+		allocator.MemberKey(bk.ks, bk.id.Zone, bk.id.Suffix), JournalIsConsistent)
 
 	// Initialize server.
 	bk.srv = server.MustLoopback()
-
-	var state = allocator.NewObservedState(bk.ks, allocator.MemberKey(bk.ks, bk.id.Zone, bk.id.Suffix))
 	bk.svc = &Service{
 		jc:               pb.NewJournalClient(bk.srv.GRPCLoopback),
 		etcd:             etcd,

--- a/cmd/gazette/main.go
+++ b/cmd/gazette/main.go
@@ -77,11 +77,13 @@ func (cmdServe) Execute(args []string) error {
 			ProcessSpec:  Config.Broker.BuildProcessSpec(srv),
 		}
 		ks         = broker.NewKeySpace(Config.Etcd.Prefix)
-		allocState = allocator.NewObservedState(ks, allocator.MemberKey(ks, spec.Id.Zone, spec.Id.Suffix))
-		service    = broker.NewService(allocState, lo, etcd)
-		rjc        = protocol.NewRoutedJournalClient(lo, service)
-		tasks      = task.NewGroup(context.Background())
-		signalCh   = make(chan os.Signal, 1)
+		allocState = allocator.NewObservedState(ks,
+			allocator.MemberKey(ks, spec.Id.Zone, spec.Id.Suffix),
+			broker.JournalIsConsistent)
+		service  = broker.NewService(allocState, lo, etcd)
+		rjc      = protocol.NewRoutedJournalClient(lo, service)
+		tasks    = task.NewGroup(context.Background())
+		signalCh = make(chan os.Signal, 1)
 	)
 	protocol.RegisterJournalServer(srv.GRPCServer, service)
 	srv.HTTPMux.Handle("/", http_gateway.NewGateway(rjc))

--- a/consumer/key_space_test.go
+++ b/consumer/key_space_test.go
@@ -1,0 +1,28 @@
+package consumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.gazette.dev/core/allocator"
+	pc "go.gazette.dev/core/consumer/protocol"
+	"go.gazette.dev/core/keyspace"
+)
+
+func TestShardConsistencyCases(t *testing.T) {
+	var status, primaryStatus = new(pc.ReplicaStatus), &pc.ReplicaStatus{Code: pc.ReplicaStatus_PRIMARY}
+	var asn = keyspace.KeyValue{Decoded: allocator.Assignment{Slot: 1, AssignmentValue: status}}
+	var all = keyspace.KeyValues{asn, {Decoded: allocator.Assignment{Slot: 0, AssignmentValue: primaryStatus}}}
+
+	assert.False(t, ShardIsConsistent(allocator.Item{}, asn, all))
+	status.Code = pc.ReplicaStatus_STANDBY
+	assert.True(t, ShardIsConsistent(allocator.Item{}, asn, all))
+	status.Code = pc.ReplicaStatus_PRIMARY
+	assert.True(t, ShardIsConsistent(allocator.Item{}, asn, all))
+
+	// If we're FAILED, we're consistent only if the primary is also.
+	status.Code = pc.ReplicaStatus_FAILED
+	assert.False(t, ShardIsConsistent(allocator.Item{}, asn, all))
+	primaryStatus.Code = pc.ReplicaStatus_FAILED
+	assert.True(t, ShardIsConsistent(allocator.Item{}, asn, all))
+}

--- a/consumer/test_support_test.go
+++ b/consumer/test_support_test.go
@@ -206,7 +206,7 @@ func newTestFixture(t assert.TestingT) (*testFixture, func()) {
 	ks.WatchApplyDelay = 0 // Speed test execution.
 
 	var state = allocator.NewObservedState(ks,
-		allocator.MemberKey(ks, localID.Zone, localID.Suffix))
+		allocator.MemberKey(ks, localID.Zone, localID.Suffix), ShardIsConsistent)
 
 	var tmpSqlite, err = ioutil.TempFile("", "consumer-test")
 	assert.NoError(t, err)

--- a/consumertest/consumer.go
+++ b/consumertest/consumer.go
@@ -59,7 +59,7 @@ func NewConsumer(args Args) *Consumer {
 	var (
 		id        = pb.ProcessSpec_ID{Zone: args.Zone, Suffix: args.Suffix}
 		ks        = consumer.NewKeySpace(args.Root)
-		state     = allocator.NewObservedState(ks, allocator.MemberKey(ks, id.Zone, id.Suffix))
+		state     = allocator.NewObservedState(ks, allocator.MemberKey(ks, id.Zone, id.Suffix), consumer.ShardIsConsistent)
 		srv       = server.MustLoopback()
 		svc       = consumer.NewService(args.App, state, args.Journals, srv.GRPCLoopback, args.Etcd)
 		tasks     = task.NewGroup(context.Background())


### PR DESCRIPTION
This allows `broker/protocol.JournalSpec.IsConsistent` to be hoisted out
of the `protocol` package and into the `broker` package instead, which
is a step towards removing all dependency on the `keyspace` package
(which in turn depends on `etcd`) from the `protocol` package.

A similar refactor is done for ShardIsConsistent which removes
dependence on `keyspace` & `etcd` from `consumer/protocol` as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/251)
<!-- Reviewable:end -->
