### PR TITLE
additional metrics work

### DIFF
--- a/broker/append_api.go
+++ b/broker/append_api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net"
-	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -19,7 +18,7 @@ func (svc *Service) Append(stream pb.Journal_AppendServer) (err error) {
 		fsm appendFSM
 		req *pb.AppendRequest
 	)
-	defer instrumentJournalServerOp("Append", &err, &fsm.resolved, time.Now())
+	defer instrumentJournalServerRPC("Append", &err, &fsm.resolved)()
 
 	defer func() {
 		if err != nil {

--- a/broker/doc.go
+++ b/broker/doc.go
@@ -12,9 +12,13 @@ import (
 )
 
 var (
-	journalServerResponseTimeSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "gazette_journal_server_response_time_seconds",
-		Help: "DEPRECATED Response time of JournalServer operations (use gRPC metrics instead of this)",
+	journalServerStarted = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gazette_journal_server_started_totals",
+		Help: "Total number of started JournalServer RPC invocations, by operation.",
+	}, []string{"operation"})
+	journalServerCompleted = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gazette_journal_server_completed_totals",
+		Help: "Total number of completed JournalServer RPC invocations, by operation & response status",
 	}, []string{"operation", "status"})
 	writeHeadGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "gazette_write_head",

--- a/broker/fragment/doc.go
+++ b/broker/fragment/doc.go
@@ -38,6 +38,14 @@ var (
 		Name: "gazette_spool_rollback_bytes_total",
 		Help: "Total number of bytes rolled-back from journal fragment spools.",
 	})
+	spoolCompletedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "gazette_spool_completed_total",
+		Help: "Total number of journal fragment spools which have been completed, and are ready for persisting.",
+	})
+	spoolPersistedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "gazette_spool_persisted_total",
+		Help: "Total number of journal fragment spools which were persisted (by this server, or by another and then verified by this server).",
+	})
 
 	// DEPRECATED metrics to be removed:
 	committedBytesTotal = promauto.NewCounter(prometheus.CounterOpts{

--- a/broker/fragment/spool.go
+++ b/broker/fragment/spool.go
@@ -123,6 +123,7 @@ func (s *Spool) applyCommit(r *pb.ReplicateRequest, primary bool) pb.ReplicateRe
 			s.finishCompression()
 		}
 		if s.ContentLength() != 0 {
+			spoolCompletedTotal.Inc()
 			s.observer.SpoolComplete(*s, primary)
 		}
 		// If the proposal is strictly greater than our Fragment, take the proposal registers.

--- a/broker/fragments_api.go
+++ b/broker/fragments_api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"sort"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/broker/fragment"
@@ -17,7 +16,7 @@ var defaultPageLimit = int32(1000)
 // ListFragments dispatches the JournalServer.ListFragments API.
 func (svc *Service) ListFragments(ctx context.Context, req *pb.FragmentsRequest) (resp *pb.FragmentsResponse, err error) {
 	var res *resolution
-	defer instrumentJournalServerOp("ListFragments", &err, &res, time.Now())
+	defer instrumentJournalServerRPC("ListFragments", &err, &res)()
 
 	defer func() {
 		if err != nil {

--- a/broker/list_apply_api.go
+++ b/broker/list_apply_api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/clientv3"
@@ -16,7 +15,7 @@ import (
 
 // List dispatches the JournalServer.List API.
 func (svc *Service) List(ctx context.Context, req *pb.ListRequest) (resp *pb.ListResponse, err error) {
-	defer instrumentJournalServerOp("List", &err, nil, time.Now())
+	defer instrumentJournalServerRPC("List", &err, nil)()
 
 	defer func() {
 		if err != nil {
@@ -75,7 +74,7 @@ func (svc *Service) List(ctx context.Context, req *pb.ListRequest) (resp *pb.Lis
 
 // Apply dispatches the JournalServer.Apply API.
 func (svc *Service) Apply(ctx context.Context, req *pb.ApplyRequest) (resp *pb.ApplyResponse, err error) {
-	defer instrumentJournalServerOp("Apply", &err, nil, time.Now())
+	defer instrumentJournalServerRPC("Apply", &err, nil)()
 
 	defer func() {
 		if err != nil {

--- a/broker/read_api.go
+++ b/broker/read_api.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
-	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -21,7 +20,7 @@ import (
 // Read dispatches the JournalServer.Read API.
 func (svc *Service) Read(req *pb.ReadRequest, stream pb.Journal_ReadServer) (err error) {
 	var resolved *resolution
-	defer instrumentJournalServerOp("Read", &err, &resolved, time.Now())
+	defer instrumentJournalServerRPC("Read", &err, &resolved)()
 
 	defer func() {
 		if err != nil {

--- a/broker/replicate_api.go
+++ b/broker/replicate_api.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/broker/fragment"
@@ -18,7 +17,7 @@ func (svc *Service) Replicate(stream pb.Journal_ReplicateServer) (err error) {
 		req      *pb.ReplicateRequest
 		resolved *resolution
 	)
-	defer instrumentJournalServerOp("Replicate", &err, &resolved, time.Now())
+	defer instrumentJournalServerRPC("Replicate", &err, &resolved)()
 
 	defer func() {
 		if err != nil {

--- a/examples/stream-sum/stream_sum.go
+++ b/examples/stream-sum/stream_sum.go
@@ -401,7 +401,6 @@ func verify(emit func(Chunk), chunkCh <-chan Chunk, verifyCh, actualCh <-chan Su
 	//   of total delay before the client detects the failure has cleared.
 	// * Add 10 seconds of extra headroom, as the test is likely hosing the machine.
 	var timeoutSeq = []time.Duration{
-		50 * time.Millisecond,
 		100 * time.Millisecond,
 		250 * time.Millisecond,
 		500 * time.Millisecond,

--- a/mainboilerplate/diagnostics.go
+++ b/mainboilerplate/diagnostics.go
@@ -7,6 +7,7 @@ import (
 	_ "net/http/pprof" // Import for /debug/pprof
 	"os"
 
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -22,6 +23,12 @@ type DiagnosticsConfig struct {
 // deferred, which recover a panic and attempt to log a K8s termination message.
 func InitDiagnosticsAndRecover(cfg DiagnosticsConfig) func() {
 	grpc.EnableTracing = true
+
+	// Turn on histograms for client & server RPCs. These can be very helpful to
+	// have around, but are also expensive to track at scale. You may want to
+	// consider rules which selectively discard some histograms at scrape time.
+	grpc_prometheus.EnableHandlingTimeHistogram()
+	grpc_prometheus.EnableClientHandlingTimeHistogram()
 
 	// Package "net/http/pprof" serves /debug/pprof/.
 	// Package "expvar" serves /debug/vars

--- a/server/server.go
+++ b/server/server.go
@@ -85,6 +85,9 @@ func New(iface string, port uint16) (*Server, error) {
 		// connections, as it's crucial for quick cluster recovery from
 		// partitions, etc.
 		grpc.WithBackoffMaxDelay(time.Millisecond*500),
+		// Instrument client for gRPC metric collection.
+		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
+		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
 	)
 
 	if err != nil {


### PR DESCRIPTION
* More grpc-prometheus instrumentation
*  Remove broken response-time metric, add RPC starts & completions with operation & status.
* Add completed & persisted spools metric (allows for deriving persister queue depth).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/263)
<!-- Reviewable:end -->
