### PR TITLE
Ci releases

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -1,0 +1,137 @@
+name: Gazette Continuous Integration
+
+# We build on any push, or when a release is created.
+on:
+  push: {}
+  release:
+    # Without this additional restriction, GH actions will trigger multiple runs for a single
+    # release, because it fires off separate events creating vs publishing the release.
+    types: [created]
+
+env:
+  # This is only used as the cache key to prevent rebuilding rocksdb every time. Eventually
+  # we'll need to figure out a solution that doesn't duplicate this version everywhere.
+  # For now, ensure that it's changed both here and in mk/common-config.mk
+  ROCKSDB_VERSION: "6.7.3"
+  GITHUB_EVENT_JSON: '${{ toJson(github.event) }}'
+
+jobs:
+  build:
+    name: 'Build'
+    runs-on: ubuntu-18.04
+    steps:
+
+        # This is just really useful info to have when debugging issues with the action itself
+      - name: 'Print event info'
+        run: |
+          echo 'event_name=${{ github.event_name }}';
+          echo 'ref=${{ github.ref }}';
+          echo "Event Json: ";
+          echo '$GITHUB_EVENT_JSON'
+
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+
+        # sets outputs for version, docker tag, and whether we should push images and upload release
+        # artifacts. These outputs are used by later steps
+      - name: 'Release Info'
+        id: release_info
+        run: |
+          is_release=${{ github.event_name == 'release' }}
+          if [[ "$is_release" == "true" ]]; then
+            push_images=true
+            tag_name=${{ github.event.release.tag_name }}
+            # the version regex doesn't need to be super sophisticated, since the goal is not to
+            # validate that this is a semantic version number. Rather the goal is just to see if 
+            # matches the typical pattern we use for release tags (e.g. v0.86.1). If it does, then
+            # we'll remove the 'v' prefix and use the remainder as the docker tag
+            # If a release tag does not match that format, then we'll just use the tag value as is
+            if echo "$tag_name" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+              version="${tag_name#v}"
+            else
+              version="${tag_name}"
+            fi
+          else
+            # this is not a release, so we'll use 'latest-dev-<sha>' for the version number
+            # and just 'latest-dev' for the docker tag
+            sha=${{ github.sha }}
+            version="${docker_tag}-${sha:0:7}"
+            # if this is a master build, then we'll treat this as a release and just use the 
+            # hard-coded tag as the docker image tag
+            if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
+                # we don't want to put the git sha in the docker tag because otherwise they'll
+                # accumulate forever and just clutter up the page on docker hub. So 'latest-dev'
+                # just always gets you the most recent master build, and if you want a specific master
+                # build, then you can use the '@sha256:...' syntax
+                docker_tag="latest-dev"
+                push_images='true'
+            else
+                push_images='false'
+            fi
+          fi
+          echo ::set-output name=VERSION::${version}
+          echo ::set-output name=DOCKER_TAG::${docker_tag:-$version}
+          echo ::set-output name=PUSH_IMAGES::${push_images}
+          echo ::set-output name=IS_RELEASE::${is_release}
+
+        # try to load the ci-builder docker image from the cache. If this misses, then it will be 
+        # built automatically by a make rule. A later step will then run 'docker save' to export the
+        # image as a tar archive so we can cache it.
+      - name: 'CI Builder Docker Image Cache'
+        id: 'ci_builder_cache'
+        uses: actions/cache@v2
+        with:
+          key: ci-builder-${{ hashFiles('mk/ci-builder.Dockerfile') }}
+          path: ".build/ci-builder-image.tar"
+
+        # The 'c<n>' in these Cache steps is just for changing the cache key so that
+        # we can manually invalidate the cache if we need
+      - name: 'RocksDB Cache'
+        uses: actions/cache@v2
+        with:
+          key: rocksdb-c3-${{ env.ROCKSDB_VERSION }}
+          path: ".build-ci/rocksdb-v${{ env.ROCKSDB_VERSION }}"
+
+      - name: 'Go Module Cache'
+        uses: actions/cache@v2
+        with:
+          key: go-mod-c3-${{ hashFiles('go.sum') }}
+          path: ".build-ci/go-path/pkg"
+          # If we don't have a cached directory that matches the hash exactly,
+          # then this will allow a non-matching directory to be pulled in. This is safe
+          # because go will use its own finer-grained cache invalidation logic
+          restore-keys: "go-mod-c3-"
+
+      - name: 'Build Binaries'
+        run: "make as-ci target=release-linux-binaries VERSION=${{ steps.release_info.outputs.VERSION }}"
+
+      - name: 'Test'
+        run: "make as-ci target=go-test-ci VERSION=${{ steps.release_info.outputs.VERSION }}"
+
+        # We upload this to the artifacts that are attached to the action just to make it easy for
+        # someone to pull down a build from another branch
+      - name: 'Upload Binaries'
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'gazette-x86_64-linux-gnu.zip'
+          path: ".build-ci/gazette-x86_64-linux-gnu.zip"
+
+      - name: 'Upload Release Binaries'
+        if: steps.release_info.outputs.IS_RELEASE == 'true'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_name: gazette-x86_64-linux-gnu.zip
+          asset_path: ".build-ci/gazette-x86_64-linux-gnu.zip"
+          upload_url: "${{ github.event.release.upload_url }}"
+          asset_content_type: application/zip
+
+      - name: 'Build and Push Docker Images'
+        if: steps.release_info.outputs.PUSH_IMAGES == 'true'
+        run: |
+          docker login -u '${{ secrets.DOCKER_USERNAME }}' -p '${{ secrets.DOCKER_PASSWORD }}' ${{ secrets.DOCKER_REGISTRY }}
+          make as-ci target=ci-release-gazette-examples VERSION=${{ steps.release_info.outputs.VERSION }}
+          make as-ci target=ci-release-gazette-broker VERSION=${{ steps.release_info.outputs.VERSION }}
+          make as-ci target=push-to-registry registry=${{ secrets.DOCKER_REGISTRY }} release_tag=${{ steps.release_info.outputs.DOCKER_TAG }}
+

--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -138,5 +138,5 @@ jobs:
           docker login -u '${{ secrets.DOCKER_USERNAME }}' -p '${{ secrets.DOCKER_PASSWORD }}' ${{ secrets.DOCKER_REGISTRY }}
           make as-ci target=ci-release-gazette-examples VERSION=${{ steps.release_info.outputs.VERSION }}
           make as-ci target=ci-release-gazette-broker VERSION=${{ steps.release_info.outputs.VERSION }}
-          make as-ci target=push-to-registry registry=${{ secrets.DOCKER_REGISTRY }} release_tag=${{ steps.release_info.outputs.DOCKER_TAG }}
+          make as-ci target=push-to-registry REGISTRY=${{ secrets.DOCKER_REGISTRY }} RELEASE_TAG=${{ steps.release_info.outputs.DOCKER_TAG }}
 

--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -2,7 +2,9 @@ name: Gazette Continuous Integration
 
 # We build on any push, or when a release is created.
 on:
-  push: {}
+  push:
+    tags-ignore:
+      - '*'
   release:
     # Without this additional restriction, GH actions will trigger multiple runs for a single
     # release, because it fires off separate events creating vs publishing the release.

--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -1,8 +1,11 @@
 name: Gazette Continuous Integration
 
-# We build on any push, or when a release is created.
+# We build on any push to a branch, or when a release is created.
 on:
   push:
+    branches:
+      - '*'
+    # ignore pushes to tags, since those ought to be handled by the release created event
     tags-ignore:
       - '*'
   release:

--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - '*'
-    # ignore pushes to tags, since those ought to be handled by the release created event
+    # Ignore pushes to tags, since those ought to be handled by the release created event.
     tags-ignore:
       - '*'
   release:
@@ -16,7 +16,7 @@ on:
 env:
   # This is only used as the cache key to prevent rebuilding rocksdb every time. Eventually
   # we'll need to figure out a solution that doesn't duplicate this version everywhere.
-  # For now, ensure that it's changed both here and in mk/common-config.mk
+  # For now, ensure that it's changed both here and in mk/common-config.mk.
   ROCKSDB_VERSION: "6.7.3"
   GITHUB_EVENT_JSON: '${{ toJson(github.event) }}'
 
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
 
-        # This is just really useful info to have when debugging issues with the action itself
+        # This is just really useful info to have when debugging issues with the action itself.
       - name: 'Print event info'
         run: |
           echo 'event_name=${{ github.event_name }}';
@@ -37,8 +37,8 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v2
 
-        # sets outputs for version, docker tag, and whether we should push images and upload release
-        # artifacts. These outputs are used by later steps
+        # Sets outputs for version, docker tag, and whether we should push images and upload release
+        # artifacts. These outputs are used by later steps.
       - name: 'Release Info'
         id: release_info
         run: |
@@ -46,28 +46,28 @@ jobs:
           if [[ "$is_release" == "true" ]]; then
             push_images=true
             tag_name=${{ github.event.release.tag_name }}
-            # the version regex doesn't need to be super sophisticated, since the goal is not to
-            # validate that this is a semantic version number. Rather the goal is just to see if 
+            # The version regex doesn't need to be super sophisticated, since the goal is not to
+            # validate that this is a semantic version number. Rather the goal is just to see if
             # matches the typical pattern we use for release tags (e.g. v0.86.1). If it does, then
             # we'll remove the 'v' prefix and use the remainder as the docker tag
-            # If a release tag does not match that format, then we'll just use the tag value as is
+            # If a release tag does not match that format, then we'll just use the tag value as is.
             if echo "$tag_name" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
               version="${tag_name#v}"
             else
               version="${tag_name}"
             fi
           else
-            # this is not a release, so we'll use 'latest-dev-<sha>' for the version number
-            # and just 'latest-dev' for the docker tag
+            # This is not a release, so we'll use 'latest-dev-<sha>' for the version number
+            # and just 'latest-dev' for the docker tag.
             sha=${{ github.sha }}
             version="${docker_tag}-${sha:0:7}"
-            # if this is a master build, then we'll treat this as a release and just use the 
-            # hard-coded tag as the docker image tag
+            # If this is a master build, then we'll treat this as a release and just use the 
+            # hard-coded tag as the docker image tag.
             if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
-                # we don't want to put the git sha in the docker tag because otherwise they'll
+                # We don't want to put the git sha in the docker tag because otherwise they'll
                 # accumulate forever and just clutter up the page on docker hub. So 'latest-dev'
                 # just always gets you the most recent master build, and if you want a specific master
-                # build, then you can use the '@sha256:...' syntax
+                # build, then you can use the '@sha256:...' syntax.
                 docker_tag="latest-dev"
                 push_images='true'
             else
@@ -79,7 +79,7 @@ jobs:
           echo ::set-output name=PUSH_IMAGES::${push_images}
           echo ::set-output name=IS_RELEASE::${is_release}
 
-        # try to load the ci-builder docker image from the cache. If this misses, then it will be 
+        # Try to load the ci-builder docker image from the cache. If this misses, then it will be 
         # built automatically by a make rule. A later step will then run 'docker save' to export the
         # image as a tar archive so we can cache it.
       - name: 'CI Builder Docker Image Cache'
@@ -90,7 +90,7 @@ jobs:
           path: ".build/ci-builder-image.tar"
 
         # The 'c<n>' in these Cache steps is just for changing the cache key so that
-        # we can manually invalidate the cache if we need
+        # we can manually invalidate the cache if we need.
       - name: 'RocksDB Cache'
         uses: actions/cache@v2
         with:
@@ -104,7 +104,7 @@ jobs:
           path: ".build-ci/go-path/pkg"
           # If we don't have a cached directory that matches the hash exactly,
           # then this will allow a non-matching directory to be pulled in. This is safe
-          # because go will use its own finer-grained cache invalidation logic
+          # because go will use its own finer-grained cache invalidation logic.
           restore-keys: "go-mod-c3-"
 
       - name: 'Build Binaries'
@@ -114,7 +114,7 @@ jobs:
         run: "make as-ci target=go-test-ci VERSION=${{ steps.release_info.outputs.VERSION }}"
 
         # We upload this to the artifacts that are attached to the action just to make it easy for
-        # someone to pull down a build from another branch
+        # someone to pull down a build from another branch.
       - name: 'Upload Binaries'
         uses: actions/upload-artifact@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,11 @@ ${WORKDIR}/gazette-x86_64-linux-gnu.zip: go-install
 	cd ${WORKDIR}/go-path/bin/
 	zip gazette-x86_64-linux-gnu.zip gazette gazctl
 
+# Builds a zip file containing both the gazette and gazctl release binaries. This target may only be run
+# on a linux host, since we don't currently support cross-compilation (we may want to in the
+# future).
 release-linux-binaries: go-install
-	# sanity check, since our make builds don't support cross-compilation at the moment
+	@# sanity check, since our make builds don't support cross-compilation at the moment
 	@test "$(shell uname -io)" = "x86_64 GNU/Linux" || (echo "only x86_64 linux binaries are produced" && exit 1)
 	@rm -f ${WORKDIR}/gazette-x86_64-linux-gnu.zip
 	zip -j ${WORKDIR}/gazette-x86_64-linux-gnu.zip ${WORKDIR}/go-path/bin/gazette ${WORKDIR}/go-path/bin/gazctl

--- a/Makefile
+++ b/Makefile
@@ -38,14 +38,14 @@ include mk/microk8s.mk
 include mk/cmd-reference.mk
 
 # Push the broker & example image to a specified private registry.
-# Override the registry to use by passing a "registry=" flag to make.
-registry=localhost:32000
-release_tag=latest
+# Override the registry to use by passing a "REGISTRY=" flag to make.
+REGISTRY=localhost:32000
+RELEASE_TAG=latest
 push-to-registry:
-	docker tag gazette/broker:latest   $(registry)/broker:$(release_tag)
-	docker tag gazette/examples:latest $(registry)/examples:$(release_tag)
-	docker push $(registry)/broker:$(release_tag)
-	docker push $(registry)/examples:$(release_tag)
+	docker tag gazette/broker:latest $(REGISTRY)/broker:$(RELEASE_TAG)
+	docker tag gazette/examples:latest $(REGISTRY)/examples:$(RELEASE_TAG)
+	docker push $(REGISTRY)/broker:$(RELEASE_TAG)
+	docker push $(REGISTRY)/examples:$(RELEASE_TAG)
 
 ${WORKDIR}/gazette-x86_64-linux-gnu.zip: go-install
 	cd ${WORKDIR}/go-path/bin/

--- a/mk/ci-builder.Dockerfile
+++ b/mk/ci-builder.Dockerfile
@@ -1,5 +1,10 @@
 # 18.04 (bionic) is latest Ubuntu LTS release. We require some of its updated
 # packages (notably libzstd) over Debian stretch.
+#
+# Note that this image will be cached in Github Actions, and the cache key is computed by hashing
+# this file. This works only so long as there are no _other_ files that go into the final image.
+# So if you add any ADD or COPY directives, be sure to update the cache key in the github actions 
+# workflow yaml
 FROM ubuntu:18.04
 
 RUN apt-get update -y \
@@ -18,6 +23,7 @@ RUN apt-get update -y \
       libzstd-dev \
       protobuf-compiler \
       zlib1g-dev \
+      zip \
  && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.14.2
@@ -63,3 +69,4 @@ RUN curl -L -o /tmp/etcd.tgz \
  && etcd --version
 
 WORKDIR /gazette
+

--- a/mk/common-build.mk
+++ b/mk/common-build.mk
@@ -12,6 +12,7 @@ ci-builder-image: ${WORKDIR}/ci-builder-image.tar
 # layer, and also allows the tar file to be cached
 ${WORKDIR}/ci-builder-image.tar:
 	docker build -t gazette/ci-builder:latest - <  ${COREDIR}/mk/ci-builder.Dockerfile
+	mkdir -p ${WORKDIR}
 	docker save -o ${WORKDIR}/ci-builder-image.tar gazette/ci-builder:latest
 
 # The as-ci rule recursively calls `make` _within_ a instance of the ci-builder-image,

--- a/mk/common-build.mk
+++ b/mk/common-build.mk
@@ -43,7 +43,7 @@ as-ci: ci-builder-image
 		--env GOCACHE=$${WORK_CI}/go-build-cache \
 		--mount src=/var/run/docker.sock,target=/var/run/docker.sock,type=bind \
 		gazette/ci-builder /bin/sh -ec \
-			"make ${target} VERSION=${VERSION} DATE=${DATE}"
+			"make ${target} VERSION=${VERSION} DATE=${DATE} REGISTRY=${REGISTRY} RELEASE_TAG=${RELEASE_TAG}"
 
 # Go build & test targets.
 go-install:   $(ROCKSDIR)/librocksdb.so $(protobuf-targets)

--- a/mk/common-config.mk
+++ b/mk/common-config.mk
@@ -10,7 +10,7 @@ NPROC := $(if ${NPROC},${NPROC},$(shell nproc))
 
 # Version of Rocks to build against.
 # - This is tightly coupled github.com/tecbot/gorocksdb (update them together).
-# - Also update .circleci/config.yml
+# - Also update .github/workflows/ci-workflow.yaml
 ROCKSDB_VERSION = 6.7.3
 
 # Repository root (the directory of the invoked Makefile).


### PR DESCRIPTION
This brings with it a few other changes to the build system:

- Building and publishing official release Docker images to docker hub
- Building and publishing binary releases to the Github Releases
- Build RocksDB with `PORTABLE=1` to prevent it from using
  `-march=native`, which may cause it to use avx512 automatically
  (meaning rocksdb would crash on hardware that doesn't support avx512).
  This ensures that rocks will never use avx512.
- Changes how the 'ci-builder' docker image is built to allow taking
  advantage of cache in GH actions instead of needing to publish the
  image to docker hub
- Set the user id when invoking docker in the `as-ci` target so that the
  output files won't be owned by the root user (fixes issues with
  caching and allows removal without sudo)
- Added a new `release-linux-binaries` make target, which outputs a zip
  containing `gazette` and `gazctl` binaries to the build directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/269)
<!-- Reviewable:end -->
