### PR TITLE
don't use as-ci when pushing docker images

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -138,5 +138,5 @@ jobs:
           docker login -u '${{ secrets.DOCKER_USERNAME }}' -p '${{ secrets.DOCKER_PASSWORD }}' ${{ secrets.DOCKER_REGISTRY }}
           make as-ci target=ci-release-gazette-examples VERSION=${{ steps.release_info.outputs.VERSION }}
           make as-ci target=ci-release-gazette-broker VERSION=${{ steps.release_info.outputs.VERSION }}
-          make as-ci target=push-to-registry REGISTRY=${{ secrets.DOCKER_REGISTRY }} RELEASE_TAG=${{ steps.release_info.outputs.DOCKER_TAG }}
+          make push-to-registry REGISTRY=${{ secrets.DOCKER_REGISTRY }} RELEASE_TAG=${{ steps.release_info.outputs.DOCKER_TAG }}
 


### PR DESCRIPTION
Turns out there were _two_ problems with the first attempt. One was that I had mistyped the registry name in the github secret (it should be `docker.io/gazette`). The second problem was that I had mistakenly used `as-ci` in the docker push step, which prevented docker from reading the correct credentials. Both of those have been addressed, so I'm hopeful that the master builds will succeed after this is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/270)
<!-- Reviewable:end -->
