### PR TITLE
migrate docs from circleci to github actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,9 @@
    :alt: Gazette Logo
 
 
-.. image:: https://circleci.com/gh/gazette/core.svg?style=svg
-   :target: https://circleci.com/gh/gazette/core
-   :alt: CircleCI
+.. image:: https://github.com/gazette/core/workflows/Gazette%20Continuous%20Integration/badge.svg
+   :target: https://github.com/gazette/core/actions?query=workflow%3A%22Gazette+Continuous+Integration%22
+   :alt: Gazette Continuous Integration
 .. image:: https://godoc.org/go.gazette.dev/core?status.svg
    :target: https://godoc.org/go.gazette.dev/core
    :alt: GoDoc

--- a/docs/overview-build-and-test.rst
+++ b/docs/overview-build-and-test.rst
@@ -48,11 +48,11 @@ Docker for Desktop or Minikube). Soak tests run with ``latest`` images.
 
    $ kubectl apply -k ./kustomize/test/deploy-stream-sum-with-crash-tests/
 
-Push images to a registry. If ``registry`` is not specified, it defaults to ``localhost:32000`` (which is used by MicroK8s):
+Push images to a registry. If ``REGISTRY`` is not specified, it defaults to ``localhost:32000`` (which is used by MicroK8s):
 
 .. code-block:: console
 
-   $ make push-to-registry registry=my.registry.com
+   $ make push-to-registry REGISTRY=my.registry.com
 
 The ``kustomize`` directory also has a
 :githubsource:`helper manifest<kustomize/test/run-with-local-registry/kustomization.yaml>` for using

--- a/docs/overview-intro.rst
+++ b/docs/overview-intro.rst
@@ -4,9 +4,9 @@
 Overview
 =========
 
-.. image:: https://circleci.com/gh/gazette/core.svg?style=svg
-   :target: https://circleci.com/gh/gazette/core
-   :alt: CircleCI
+.. image:: https://github.com/gazette/core/workflows/Gazette%20Continuous%20Integration/badge.svg
+   :target: https://github.com/gazette/core/actions?query=workflow%3A%22Gazette+Continuous+Integration%22
+   :alt: Gazette Continuous Integration
 .. image:: https://godoc.org/go.gazette.dev/core?status.svg
    :target: https://godoc.org/go.gazette.dev/core
    :alt: GoDoc


### PR DESCRIPTION
Just some minor docs updates related to the change from circleci to github actions. 

One thing that's _not_ covered here is the image names used in the kustomize templates. These currently use `gazette/broker` (without a registry host). One of the benefits(?) of docker hub is that it's the default registry, so image names without a host will automatically be pulled from there. There's a couple of ways that we could address that in the future, but one idea would be to add a `kustomization.yaml` that just modifies the image names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/272)
<!-- Reviewable:end -->
