### PR TITLE
Rocks builds

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -88,14 +88,6 @@ jobs:
           key: ci-builder-${{ hashFiles('mk/ci-builder.Dockerfile') }}
           path: ".build/ci-builder-image.tar"
 
-        # The 'c<n>' in these Cache steps is just for changing the cache key so that
-        # we can manually invalidate the cache if we need.
-      - name: 'RocksDB Cache'
-        uses: actions/cache@v2
-        with:
-          key: rocksdb-c3-${{ env.ROCKSDB_VERSION }}
-          path: ".build-ci/rocksdb-v${{ env.ROCKSDB_VERSION }}"
-
       - name: 'Go Module Cache'
         uses: actions/cache@v2
         with:

--- a/consumer/store-rocksdb/hooked_env.go
+++ b/consumer/store-rocksdb/hooked_env.go
@@ -1,9 +1,8 @@
 package store_rocksdb
 
 /*
-#cgo CFLAGS:   -I../../.build/rocksdb-current/include
-#cgo CPPFLAGS: -I../../.build/rocksdb-current/include
-#cgo LDFLAGS:  -L../../.build/rocksdb-current/ -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd -ldl
+#cgo static LDFLAGS: -l:librocksdb.a -l:libz.a -l:libbz2.a -l:libsnappy.a -l:liblz4.a -l:libzstd.a -lm -ldl
+#cgo !static LDFLAGS: -lrocksdb -lz -lbz2 -lsnappy -llz4 -lzstd -lm -ldl
 
 #include <sys/types.h>
 #include "rocksdb/c.h"

--- a/consumer/store-sqlite/store.go
+++ b/consumer/store-sqlite/store.go
@@ -1,7 +1,8 @@
 package store_sqlite
 
 /*
-#cgo LDFLAGS: -lsqlite3 -lrocksdb
+#cgo static LDFLAGS: -l:libsqlite3.a
+#cgo !static LDFLAGS: -lsqlite3
 
 #include "store.h"
 */

--- a/docs/overview-build-and-test.rst
+++ b/docs/overview-build-and-test.rst
@@ -88,14 +88,12 @@ instead of using ``as-ci``, then the following dependencies are required:
     * ``libsqlite3`` (development headers)
     * It's also probably useful to have the sqlite3 CLI for debugging
 
-* RocksDB: On linux systems, this will be downloaded and built automatically. You'll need to have a
-  few things in order for this to work. Most systems will already have this stuff, but it's listed
-  here anyway just for the sake of being thorough
-
-    * A C compiler toolchain (on debian-based distros, the ``build-essential`` package will have you covered)
-    * ``curl``
-    * ``ca-certificates`` (so that curl can validate the certificate of the rocksdb download server)
-    * ``tar``
+* RocksDB: This typically needs to be built from source, since we require the "Runtime Type
+  Information" feature to be enabled at compile time. The variable ``USE_RTTI=1`` is used to enable
+  that during compilation. Check out the gazette 
+  :githubsource:`ci-builder dockerfile<mk/ci-builder.Dockerfile>` to see an example of how to 
+  build and install rocksdb. Check out the `rocksdb installation docs<https://github.com/facebook/rocksdb/blob/master/INSTALL.md>`
+  for more information.
 
 Other Build Targets
 --------------------

--- a/mk/ci-release.Dockerfile
+++ b/mk/ci-release.Dockerfile
@@ -8,18 +8,15 @@ RUN apt-get update -y \
  && apt-get install --no-install-recommends -y \
       ca-certificates \
       curl \
-      libgflags2.2 \
       libjemalloc1 \
-      libsnappy1v5 \
-      libzstd1 \
  && rm -rf /var/lib/apt/lists/*
-
-# Copy binaries & librocks.so to the image. Configure Rocks for run-time linking.
-COPY * /usr/local/bin/
-RUN mv /usr/local/bin/librocksdb.so* /usr/local/lib/ && ldconfig
 
 # Run as non-privileged "gazette" user.
 RUN useradd gazette --create-home --shell /usr/sbin/nologin
 USER gazette
 WORKDIR /home/gazette
+
+# Copy binaries to the image. It's expected that rocksdb, if used at all, will be statically linked
+COPY * /usr/local/bin/
+
 

--- a/mk/common-config.mk
+++ b/mk/common-config.mk
@@ -8,11 +8,6 @@ DATE    = $(shell date +%F-%T-%Z)
 # Number of available processors for parallel builds.
 NPROC := $(if ${NPROC},${NPROC},$(shell nproc))
 
-# Version of Rocks to build against.
-# - This is tightly coupled github.com/tecbot/gorocksdb (update them together).
-# - Also update .github/workflows/ci-workflow.yaml
-ROCKSDB_VERSION = 6.7.3
-
 # Repository root (the directory of the invoked Makefile).
 ROOTDIR  = $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
 # Location of the gazette/core repository (one level up from common-config.mk)
@@ -21,8 +16,6 @@ COREDIR  = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
 # during the build process. Note the go tool ignores directories
 # with leading '.' or '_'.
 WORKDIR  = ${ROOTDIR}/.build
-# Location of RocksDB source under $WORKDIR.
-ROCKSDIR = ${WORKDIR}/rocksdb-v${ROCKSDB_VERSION}
 
 # PROTOC_INC_MODULES is an append-able list of Go modules
 # which should be included with `protoc` invocations.
@@ -33,9 +26,14 @@ PROTOC_INC_MODULES += "github.com/gogo/protobuf"
 # of its respository as currently specified by go.mod.
 module_path = $(shell go list -f '{{ .Dir }}' -m $(module))
 
-# Export appropriate CGO and run-time linker flags to build, link,
-# and run against against our copy of Rocks.
-export CGO_CFLAGS      = -I${ROCKSDIR}/include
-export CGO_CPPFLAGS    = -I${ROCKSDIR}/include
-export CGO_LDFLAGS     = -L${ROCKSDIR} -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd
-export LD_LIBRARY_PATH =   ${ROCKSDIR}
+# These linker args really ought to be set by cgo comments in the relevant files, but this is
+# currently broken in gorocksdb starting with this pr: https://github.com/tecbot/gorocksdb/pull/174
+# See this issue for a better explanation: https://github.com/tecbot/gorocksdb/issues/197
+# Note that STATIC is enabled by default here, since that is what we use for the consumer examples.
+# If you wish to disable it, pass `STATIC=` as an argument to make.
+STATIC=1
+ifdef STATIC
+	export CGO_LDFLAGS     = -l:librocksdb.a -l:libz.a -l:libbz2.a -l:libsnappy.a -l:liblz4.a -l:libzstd.a -lm -ldl
+else
+	export CGO_LDFLAGS     = -lrocksdb -lz -lbz2 -lsnappy -llz4 -lzstd -lm -ldl
+endif


### PR DESCRIPTION
This addresses a few of the issues with building/linking native libraries, and also fixes some issues with the docker-based build environments creating files that can't be deleted. See #273 for more context. This PR addresses the first portion of that, but more work will be needed in order to make it easier to build consumer applications without needing to share the main gazette makefile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/274)
<!-- Reviewable:end -->
