### PR TITLE
Fix downstream consumer builds

### DIFF
--- a/mk/common-build.mk
+++ b/mk/common-build.mk
@@ -55,7 +55,8 @@ as-ci: ci-builder-image
 		--env GOCACHE=$${WORK_CI}/go-build-cache \
 		--mount src=/var/run/docker.sock,target=/var/run/docker.sock,type=bind \
 		gazette/ci-builder /bin/sh -ec \
-			"go mod download && make ${target} VERSION=${VERSION} DATE=${DATE} REGISTRY=${REGISTRY} RELEASE_TAG=${RELEASE_TAG}"
+			"go mod download && \
+				make ${target} VERSION=${VERSION} DATE=${DATE} REGISTRY=${REGISTRY} RELEASE_TAG=${RELEASE_TAG}"
 
 # Go build & test targets.
 go-install:   $(ROCKSDIR)/librocksdb.so $(protobuf-targets)


### PR DESCRIPTION
Some of the changes from #269 ended up breaking things for consumers that depend on the gazette make files. This addresses those issues, or at least the issues that showed up in the ping-pong example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/275)
<!-- Reviewable:end -->
