### PR TITLE
Allow explicit revision of -1 on directory nodes

### DIFF
--- a/broker/journalspace/node.go
+++ b/broker/journalspace/node.go
@@ -67,7 +67,7 @@ func (n Node) IsDir() bool { return len(n.Spec.Name) == 0 || n.Spec.Name[len(n.S
 // checked separately.
 func (n *Node) Validate() error {
 	if n.IsDir() {
-		if n.Revision != 0 {
+		if n.Revision != 0 && n.Revision != -1 {
 			return pb.NewValidationError("unexpected Revision (%d)", n.Revision)
 		} else if len(n.Children) == 0 {
 			return pb.NewValidationError("expected one or more Children")

--- a/broker/journalspace/node_test.go
+++ b/broker/journalspace/node_test.go
@@ -23,6 +23,9 @@ func (s *NodeSuite) TestValidationCases(c *gc.C) {
 	node.Revision = 0
 	c.Check(node.Validate(), gc.ErrorMatches, `expected one or more Children`)
 
+	node.Revision = -1
+	c.Check(node.Validate(), gc.ErrorMatches, `expected one or more Children`)
+
 	node.Children = append(node.Children,
 		Node{Spec: pb.JournalSpec{Name: "foo"}},
 		Node{Spec: pb.JournalSpec{Name: "bar"}})


### PR DESCRIPTION
This is a follow up to the work done on #244 (in dd4539e546537da0faba64d95e9142dc77eaab89). Specifically, I missed:

> revision: -1 may be specified either at a directory or journal literal in JournalSpec YAML

Currently `revision: -1` _must_ be specified at the journal level, however, this change remedies this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/276)
<!-- Reviewable:end -->
