### PR TITLE
Etcd Revision clarifications

### DIFF
--- a/broker/journalspace/node.go
+++ b/broker/journalspace/node.go
@@ -67,7 +67,7 @@ func (n Node) IsDir() bool { return len(n.Spec.Name) == 0 || n.Spec.Name[len(n.S
 // checked separately.
 func (n *Node) Validate() error {
 	if n.IsDir() {
-		if n.Revision != 0 && n.Revision != -1 {
+		if n.Revision != 0 {
 			return pb.NewValidationError("unexpected Revision (%d)", n.Revision)
 		} else if len(n.Children) == 0 {
 			return pb.NewValidationError("expected one or more Children")

--- a/broker/journalspace/node_test.go
+++ b/broker/journalspace/node_test.go
@@ -23,9 +23,6 @@ func (s *NodeSuite) TestValidationCases(c *gc.C) {
 	node.Revision = 0
 	c.Check(node.Validate(), gc.ErrorMatches, `expected one or more Children`)
 
-	node.Revision = -1
-	c.Check(node.Validate(), gc.ErrorMatches, `expected one or more Children`)
-
 	node.Children = append(node.Children,
 		Node{Spec: pb.JournalSpec{Name: "foo"}},
 		Node{Spec: pb.JournalSpec{Name: "bar"}})

--- a/docs/brokers-journalspecs.rst
+++ b/docs/brokers-journalspecs.rst
@@ -44,9 +44,11 @@ Etcd Revisions
 JournalSpecs retrieved by the ``gazctl`` tool will include their respective
 Etcd modification revisions as field ``revision`` within the rendered YAML.
 
-When applying YAML specs via ``gazctl journals apply``, any specs which omit
-``revision`` assume a value of zero (implying the journal must not exist).
-The revisions of specs are always compared to the current Etcd store revision,
+When applying YAML specs via ``gazctl journals apply`` the only allowed values of
+``revision`` are 0 and -1, and if specified must only exist on the leaf-level journals
+of the spec. Any specs which omit ``revision`` assume a value of zero
+(implying the journal must not exist).  The revisions of specs are always compared
+to the current Etcd store revision,
 and an apply will fail if there's a mismatch. This prevents a ``gazctl journals edit``
 or list => modify => apply sequence from overwriting specification changes which
 may have been made in the meantime.

--- a/docs/brokers-journalspecs.rst
+++ b/docs/brokers-journalspecs.rst
@@ -44,8 +44,8 @@ Etcd Revisions
 JournalSpecs retrieved by the ``gazctl`` tool will include their respective
 Etcd modification revisions as field ``revision`` within the rendered YAML.
 
-When applying YAML specs via ``gazctl journals apply`` the only allowed values of
-``revision`` are 0 and -1, and if specified must only exist on the leaf-level journals
+When applying YAML specs via ``gazctl journals apply``
+explicitly specified ``revision`` can only exist on the leaf-level journals
 of the spec. Any specs which omit ``revision`` assume a value of zero
 (implying the journal must not exist).  The revisions of specs are always compared
 to the current Etcd store revision,


### PR DESCRIPTION
Updates broker/journalspace/node.go reverting the changes introduced in 5224810eacb90136d1a88259721b6df6be432f2c
and clarifies the documentation of revision:-1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/285)
<!-- Reviewable:end -->
