### PR TITLE
fix build documentation target names

### DIFF
--- a/docs/overview-build-and-test.rst
+++ b/docs/overview-build-and-test.rst
@@ -38,8 +38,8 @@ as ``gazette/broker:latest`` and ``gazette/examples:latest``.
 
 .. code-block:: console
 
-   $ make as-ci target=ci-release-gazette-broker
-   $ make as-ci target=ci-release-gazette-examples
+   $ make as-ci target=ci-release-gazette-broker-targets
+   $ make as-ci target=ci-release-gazette-examples-targets
 
 Deploy Gazette's continuous soak test to a Kubernetes cluster (which can be
 Docker for Desktop or Minikube). Soak tests run with ``latest`` images.


### PR DESCRIPTION
Updating documentation about build to match the current target name in the Makefile

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/286)
<!-- Reviewable:end -->
