### PR TITLE
brokertest: fix graceful stop test flake

### DIFF
--- a/broker/append_api_test.go
+++ b/broker/append_api_test.go
@@ -165,7 +165,13 @@ func TestAppendBadlyBehavedClientCases(t *testing.T) {
 	failCtxCancel() // Cancel the stream.
 
 	_, err = stream.CloseAndRecv()
-	require.EqualError(t, err, `rpc error: code = Canceled desc = context canceled`)
+	require.Contains(t, []string{
+		// Error returned by appendFSM.onStreamContent, on reading an EOF
+		// without the expected empty AppendRequest (to commit).
+		`rpc error: code = Unknown desc = append stream: unexpected EOF`,
+		// Alternative error returned on reading the cancellation.
+		`rpc error: code = Canceled desc = context canceled`,
+	}, err.Error())
 
 	// Case: client attempts register modification but appends no data.
 	stream, _ = broker.client().Append(ctx)


### PR DESCRIPTION
GracefulStopTimeout can't be shrunk until after all connection setup has
occurred, as it's otherwise racing cmux matching of a mux for
newly-opened test connections.

See also soheilhy/cmux#76

Issue #301

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/302)
<!-- Reviewable:end -->
