### PR TITLE
multiple improvements to facilitate local testing contexts

### DIFF
--- a/broker/client/reader.go
+++ b/broker/client/reader.go
@@ -364,12 +364,13 @@ func mapGRPCCtxErr(ctx context.Context, err error) error {
 
 var (
 	// Map common broker error statuses into named errors.
+	ErrInsufficientJournalBrokers = errors.New(pb.Status_INSUFFICIENT_JOURNAL_BROKERS.String())
+	ErrJournalNotFound            = errors.New(pb.Status_JOURNAL_NOT_FOUND.String())
 	ErrNotJournalBroker           = errors.New(pb.Status_NOT_JOURNAL_BROKER.String())
 	ErrNotJournalPrimaryBroker    = errors.New(pb.Status_NOT_JOURNAL_PRIMARY_BROKER.String())
 	ErrOffsetNotYetAvailable      = errors.New(pb.Status_OFFSET_NOT_YET_AVAILABLE.String())
 	ErrRegisterMismatch           = errors.New(pb.Status_REGISTER_MISMATCH.String())
 	ErrWrongAppendOffset          = errors.New(pb.Status_WRONG_APPEND_OFFSET.String())
-	ErrInsufficientJournalBrokers = errors.New(pb.Status_INSUFFICIENT_JOURNAL_BROKERS.String())
 
 	// ErrOffsetJump is returned by Reader.Read to indicate that the next byte
 	// available to be read is at a larger offset than that requested (eg,

--- a/broker/client/retry_reader.go
+++ b/broker/client/retry_reader.go
@@ -98,8 +98,9 @@ func (rr *RetryReader) Read(p []byte) (n int, err error) {
 			} else {
 				return // Surface to caller.
 			}
-		case io.EOF, ErrInsufficientJournalBrokers, ErrNotJournalBroker:
+		case io.EOF, ErrInsufficientJournalBrokers, ErrNotJournalBroker, ErrJournalNotFound:
 			// Suppress logging for expected errors on first read attempt.
+			// We may be racing a concurrent Etcd watch and assignment of the broker cluster.
 			squelch = attempt == 0
 		default:
 		}

--- a/broker/fragment/index.go
+++ b/broker/fragment/index.go
@@ -204,6 +204,10 @@ func (fi *Index) Inspect(ctx context.Context, callback func(CoverSet) error) err
 func WalkAllStores(ctx context.Context, name pb.Journal, stores []pb.FragmentStore) (CoverSet, error) {
 	var set CoverSet
 
+	if DisableStores {
+		return set, nil
+	}
+
 	for _, store := range stores {
 		var err = List(ctx, store, name, func(f pb.Fragment) {
 			set, _ = set.Add(Fragment{Fragment: f})

--- a/broker/protocol/dispatcher.go
+++ b/broker/protocol/dispatcher.go
@@ -273,7 +273,7 @@ func (d *dispatcher) idToAddr(rt Route, id ProcessSpec_ID) string {
 	}
 	for i := range rt.Members {
 		if rt.Members[i] == id {
-			return rt.Endpoints[i].URL().Host
+			return rt.Endpoints[i].GRPCAddr()
 		}
 	}
 	panic("ProcessSpec_ID must be in Route.Members")

--- a/broker/protocol/endpoint.go
+++ b/broker/protocol/endpoint.go
@@ -27,6 +27,19 @@ func (ep Endpoint) URL() *url.URL {
 	}
 }
 
+// GRPCAddr maps this Endpoint into an address form suitable for gRPC to dial.
+func (ep Endpoint) GRPCAddr() string {
+	// gRPC wants the host/authority of a unix:// URL to be empty,
+	// whereas we populate it with the hostname. Strip it.
+	var addr string
+	if u := ep.URL(); u.Scheme == "unix" {
+		addr = "unix://" + u.Path
+	} else {
+		addr = u.Host
+	}
+	return addr
+}
+
 func (ep Endpoint) parse() (*url.URL, error) {
 	var url, err = url.Parse(string(ep))
 	if err != nil {

--- a/broker/protocol/endpoint_test.go
+++ b/broker/protocol/endpoint_test.go
@@ -33,4 +33,12 @@ func (s *EndpointSuite) TestURLConversion(c *gc.C) {
 	c.Check(func() { ep.URL() }, gc.PanicMatches, "not absolute: .*")
 }
 
+func (s *EndpointSuite) TestGRPCConversion(c *gc.C) {
+	var ep Endpoint = "http://host:1234/path?query"
+	c.Check(ep.GRPCAddr(), gc.Equals, "host:1234")
+
+	ep = "unix://some-host/a/path"
+	c.Check(ep.GRPCAddr(), gc.Equals, "unix:///a/path")
+}
+
 var _ = gc.Suite(&EndpointSuite{})

--- a/broker/protocol/journal_spec_extensions.go
+++ b/broker/protocol/journal_spec_extensions.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"mime"
 	"strings"
 	"text/template"
@@ -23,6 +24,10 @@ type Offset = int64
 
 // Offsets is a map of Journals and Offsets.
 type Offsets map[Journal]Offset
+
+// MaxReplication is a global bound on the degree of replication desired
+// by any JournalSpec.
+var MaxReplication int32 = math.MaxInt32
 
 // SplitMeta splits off a ";meta" path segment of this Journal, separately
 // returning the Journal and the ";meta" remainder (including leading
@@ -231,7 +236,12 @@ func (m *JournalSpec) MarshalString() string {
 
 // DesiredReplication returns the configured Replication of the spec. It
 // implements allocator.ItemValue.
-func (m *JournalSpec) DesiredReplication() int { return int(m.Replication) }
+func (m *JournalSpec) DesiredReplication() int {
+	if MaxReplication < m.Replication {
+		return int(MaxReplication)
+	}
+	return int(m.Replication)
+}
 
 // UnionJournalSpecs returns a JournalSpec combining all non-zero-valued fields
 // across |a| and |b|. Where both |a| and |b| provide a non-zero value for

--- a/broker/protocol/journal_spec_extensions_test.go
+++ b/broker/protocol/journal_spec_extensions_test.go
@@ -83,6 +83,12 @@ func (s *JournalSuite) TestSpecValidationCases(c *gc.C) {
 	c.Check(spec.Validate(), gc.ErrorMatches, `invalid Replication \(1024; .*`)
 	spec.Replication = 3
 
+	// DesiredReplication honors the lower-bound of the spec & global limit.
+	c.Check(spec.DesiredReplication(), gc.Equals, 3)
+	defer func(r int32) { MaxReplication = r }(MaxReplication)
+	MaxReplication = 1
+	c.Check(spec.DesiredReplication(), gc.Equals, 1)
+
 	spec.Labels[0].Name = "xxx xxx"
 	c.Check(spec.Validate(), gc.ErrorMatches, `Labels.Labels\[0\].Name: not a valid token \(xxx xxx\)`)
 

--- a/consumer/protocol/shard_spec_extensions.go
+++ b/consumer/protocol/shard_spec_extensions.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"fmt"
+	"math"
 	"path"
 
 	pb "go.gazette.dev/core/broker/protocol"
@@ -9,6 +10,10 @@ import (
 
 // ShardID uniquely identifies a shard processed by a Gazette consumer.
 type ShardID string
+
+// MaxHotStandbys is a global bound on the degree of hot standbys desired
+// by any ShardSpec.
+var MaxHotStandbys uint32 = math.MaxUint32
 
 // RoutedShardClient composes a ShardClient and DispatchRouter.
 type RoutedShardClient interface {
@@ -96,6 +101,9 @@ func (m *ShardSpec) MarshalString() string {
 func (m *ShardSpec) DesiredReplication() int {
 	if m.Disable {
 		return 0
+	}
+	if MaxHotStandbys < m.HotStandbys {
+		return 1 + int(MaxHotStandbys)
 	}
 	return 1 + int(m.HotStandbys)
 }

--- a/consumer/protocol/shard_spec_extensions_test.go
+++ b/consumer/protocol/shard_spec_extensions_test.go
@@ -87,12 +87,18 @@ func (s *SpecSuite) TestShardSpecValidationCases(c *gc.C) {
 func (s *SpecSuite) TestShardSpecRoutines(c *gc.C) {
 	var spec = ShardSpec{
 		Id:          "shard-id",
-		HotStandbys: 2,
+		HotStandbys: 4,
 		Disable:     false,
 		HintPrefix:  "/a/path",
 		HintBackups: 2,
 	}
+	c.Check(spec.DesiredReplication(), gc.Equals, 5)
+
+	// Expect it honors the lower-bound of the spec & global limit.
+	defer func(r uint32) { MaxHotStandbys = r }(MaxHotStandbys)
+	MaxHotStandbys = 2
 	c.Check(spec.DesiredReplication(), gc.Equals, 3)
+
 	spec.Disable = true
 	c.Check(spec.DesiredReplication(), gc.Equals, 0)
 	spec.Disable, spec.HotStandbys = false, 0

--- a/consumer/recovery.go
+++ b/consumer/recovery.go
@@ -311,6 +311,13 @@ func completeRecovery(s *shard) (_ pc.Checkpoint, err error) {
 		}
 	}
 
+	// Update read progress to reflect the restored checkpoint. Note that when we
+	// close |storeReadyCh| in just a moment, concurrent Stat RPCs may begin
+	// accessing |progress| (but not before).
+	for j, src := range cp.Sources {
+		s.progress.readThrough[j] = src.ReadThrough
+	}
+
 	close(s.storeReadyCh) // Unblocks Resolve().
 
 	return cp, nil

--- a/consumer/shard_api.go
+++ b/consumer/shard_api.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.gazette.dev/core/allocator"
 	"go.gazette.dev/core/broker/client"
 	pb "go.gazette.dev/core/broker/protocol"

--- a/mainboilerplate/client.go
+++ b/mainboilerplate/client.go
@@ -18,7 +18,8 @@ type AddressConfig struct {
 
 // MustDial dials the server address using a protocol.Dispatcher balancer, and panics on error.
 func (c *AddressConfig) MustDial(ctx context.Context) *grpc.ClientConn {
-	var cc, err = grpc.DialContext(ctx, c.Address.URL().Host,
+	var cc, err = grpc.DialContext(ctx,
+		c.Address.GRPCAddr(),
 		grpc.WithInsecure(),
 		grpc.WithBalancerName(pb.DispatcherGRPCBalancerName),
 		// Use a tighter bound for the maximum back-off delay (default is 120s).

--- a/mainboilerplate/runconsumer/run_consumer.go
+++ b/mainboilerplate/runconsumer/run_consumer.go
@@ -75,7 +75,8 @@ type Config interface {
 type BaseConfig struct {
 	Consumer struct {
 		mbp.ServiceConfig
-		Limit uint32 `long:"limit" env:"LIMIT" default:"32" description:"Maximum number of Shards this consumer process will allocate"`
+		Limit          uint32 `long:"limit" env:"LIMIT" default:"32" description:"Maximum number of Shards this consumer process will allocate"`
+		MaxHotStandbys uint32 `long:"max-hot-standbys" env:"MAX_HOT_STANDBYS" default:"3" description:"Maximum effective hot standbys of any one shard, which upper-bounds its stated hot-standbys."`
 	} `group:"Consumer" namespace:"consumer" env-namespace:"CONSUMER"`
 
 	Broker struct {
@@ -134,6 +135,8 @@ func (sc Cmd) Execute(args []string) error {
 	if bc.Etcd.Prefix == "" {
 		bc.Etcd.Prefix = fmt.Sprintf("/gazette/consumers/%T", sc.App)
 	}
+
+	pc.MaxHotStandbys = uint32(bc.Consumer.MaxHotStandbys)
 
 	var (
 		etcd = bc.Etcd.MustDial()


### PR DESCRIPTION
Thematically this PR is a bag of quality-of-life improvements that make it easier to run local testing clusters.

* Make it possible to run vanilla shard / journal specs in a single-process cluster by bounding effective replication and disabling remote stores
* Support Unix domain sockets so as not to pollute the port space if you're running a lot of these test clusters
* Squelch a spurious warning.

See individual commits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/311)
<!-- Reviewable:end -->
