### PR TITLE
consumer: shard transitions account for delete-then-create race

### DIFF
--- a/consumer/shard.go
+++ b/consumer/shard.go
@@ -161,8 +161,6 @@ var transition = func(s *shard, item, assignment keyspace.KeyValue) {
 		s.wg.Add(1) // Transition standby => primary.
 		go servePrimary(s)
 	}
-	s.resolved.spec = item.Decoded.(allocator.Item).ItemValue.(*pc.ShardSpec)
-	s.resolved.assignment = assignment
 }
 
 // serveStandby recovers and tails the shard recovery log, until the Replica is


### PR DESCRIPTION
If a shard assignment is removed (for example, because its FAILED)
and is then immediately re-created by the allocation coordinator,
we previously could fail to notice that the prior local shard was
invalidated and should be re-created.

Account for this by additionally monitoring the CreateRevision of
assignments and treating an assignment of the same or higher slot,
with a differing CreateRevision, as being a novel assignment which
requires a novel local shard to be boot-strapped.

Fixes #314

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/315)
<!-- Reviewable:end -->
