### PR TITLE
client: add new metric instrumentation for reads & appends

### DIFF
--- a/broker/client/doc.go
+++ b/broker/client/doc.go
@@ -59,3 +59,39 @@
 // PolledList, which is an important building-block for applications scaling to
 // multiple journals.
 package client
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	appendBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gazette_append_bytes_total",
+		Help: "Total number of journal bytes appended.",
+	}, []string{"journal"})
+	readBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gazette_read_bytes_total",
+		Help: "Total number of journal bytes read.",
+	}, []string{"journal"})
+	fragmentOpen = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gazette_fragment_open_total",
+		Help: "Total number of journal fragments opened for reading.",
+	}, []string{"journal", "codec"})
+	fragmentOpenBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gazette_fragment_open_bytes_total",
+		Help: "Aggregate uncompressed bytes of journal fragments opened for reading.",
+	}, []string{"journal", "codec"})
+	fragmentOpenContentLength = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gazette_fragment_open_content_length_total",
+		Help: "Aggregate content-length of journal fragments opened for reading.",
+	}, []string{"journal", "codec"})
+	readFragmentBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gazette_read_fragment_bytes_total",
+		Help: "Total number of journal fragment bytes read, excluding discarded bytes.",
+	}, []string{"journal", "codec"})
+	discardFragmentBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gazette_discard_fragment_bytes_total",
+		Help: "Total number of journal fragment bytes discarded while seeking to desired offset.",
+	}, []string{"journal", "codec"})
+)

--- a/broker/client/retry_reader.go
+++ b/broker/client/retry_reader.go
@@ -84,6 +84,7 @@ func (rr *RetryReader) Read(p []byte) (n int, err error) {
 			Response: rr.Reader.Response,
 			ctx:      rr.Reader.ctx,
 			client:   rr.Reader.client,
+			counter:  rr.Reader.counter,
 		}
 
 		var squelch bool


### PR DESCRIPTION
Give particular focus to fragment reads, surfacing the number of
client-initiated fragment reads and related size metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/317)
<!-- Reviewable:end -->
