### PR TITLE
Add DeferPublishUncommitted to message.Publisher

### DIFF
--- a/message/publisher_test.go
+++ b/message/publisher_test.go
@@ -215,6 +215,121 @@ func TestIntegrationOfPublisherWithSequencerAndReader(t *testing.T) {
 	require.NoError(t, bk.Tasks.Wait())
 }
 
+func TestDeferPublishUncommitted(t *testing.T) {
+	var etcd = etcdtest.TestClient()
+	defer etcdtest.Cleanup()
+
+	var (
+		clock Clock
+		ctx   = context.Background()
+		spec  = newTestMsgSpec("a/journal")
+		bk    = brokertest.NewBroker(t, etcd, "local", "broker")
+		ajc   = client.NewAppendService(ctx, bk.Client())
+	)
+	brokertest.CreateJournals(t, bk, spec)
+
+	// Start a long-lived RetryReader of |spec|.
+	var rr = client.NewRetryReader(ctx, bk.Client(), pb.ReadRequest{
+		Journal: spec.Name,
+		Block:   true,
+	})
+	var r = NewReadUncommittedIter(rr, newTestMsg)
+
+	var seq = NewSequencer(nil, nil, 5)
+
+	var seqPump = func() (out []testMsg) {
+		var env, err = r.Next()
+		require.NoError(t, err)
+
+		if seq.QueueUncommitted(env) == QueueAckCommitReplay {
+			// The sequencer buffer is large enough that we should never need to replay for this
+			// test.
+			panic("unexpected need to replay")
+		}
+		for {
+			if err := seq.Step(); err == io.EOF {
+				return
+			}
+			require.NoError(t, err)
+			out = append(out, *seq.Dequeued.Message.(*testMsg))
+		}
+	}
+
+	var mapping = func(Mappable) (pb.Journal, string, error) {
+		return spec.Name, labels.ContentType_JSONLines, nil
+	}
+	var pub = NewPublisher(ajc, &clock)
+
+	// Happy path: An uncommitted message can be written before a deferred one, and should get
+	// sequenced normally with respect to the deferred message, since the deferred publish is
+	// started after.
+	var _, err = pub.PublishUncommitted(mapping, &testMsg{Str: "one"})
+	require.NoError(t, err)
+	require.Equal(t, []testMsg(nil), seqPump())
+
+	fut, err := pub.DeferPublishUncommitted(spec.Name, labels.ContentType_JSONLines, new(testMsg))
+	require.NoError(t, err)
+
+	intents, err := pub.BuildAckIntents()
+	require.NoError(t, err)
+
+	require.NoError(t, fut.Resolve(&testMsg{Str: "two"}))
+	require.Equal(t, []testMsg(nil), seqPump())
+
+	writeIntents(t, ajc, intents)
+
+	var actual = seqPump()
+	require.Equal(t, 3, len(actual))
+	require.Equal(t, "one", actual[0].Str)
+	require.Equal(t, "two", actual[1].Str)
+	require.Equal(t, "", actual[2].Str)
+
+	// Sad path cases:
+	// The deferred publish message will not be seen because it sequences before "three"
+	fut, err = pub.DeferPublishUncommitted(spec.Name, labels.ContentType_JSONLines, new(testMsg))
+	require.NoError(t, err)
+
+	_, err = pub.PublishUncommitted(mapping, &testMsg{Str: "three"})
+	require.NoError(t, err)
+	require.Equal(t, []testMsg(nil), seqPump())
+	intents, err = pub.BuildAckIntents()
+	require.NoError(t, err)
+	require.NoError(t, fut.Resolve(&testMsg{Str: "wont see four"}))
+	require.Equal(t, []testMsg(nil), seqPump())
+
+	writeIntents(t, ajc, intents)
+	actual = seqPump()
+	require.Equal(t, 2, len(actual))
+	require.Equal(t, "three", actual[0].Str)
+	require.Equal(t, "", actual[1].Str)
+
+	// The deferred publish isn't resolved until after the acks were written, so will not be seen.
+	_, err = pub.PublishUncommitted(mapping, &testMsg{Str: "five"})
+	require.NoError(t, err)
+	require.Equal(t, []testMsg(nil), seqPump())
+
+	fut, err = pub.DeferPublishUncommitted(spec.Name, labels.ContentType_JSONLines, new(testMsg))
+	require.NoError(t, err)
+
+	intents, err = pub.BuildAckIntents()
+	require.NoError(t, err)
+	writeIntents(t, ajc, intents)
+
+	actual = seqPump()
+	require.Equal(t, 2, len(actual))
+	require.Equal(t, "five", actual[0].Str)
+	require.Equal(t, "", actual[1].Str)
+
+	require.NoError(t, fut.Resolve(&testMsg{Str: "wont see six"}))
+	require.Equal(t, []testMsg(nil), seqPump())
+
+	_, err = pub.PublishCommitted(mapping, &testMsg{Str: "seven"})
+	require.NoError(t, err)
+	actual = seqPump()
+	require.Equal(t, 1, len(actual))
+	require.Equal(t, "seven", actual[0].Str)
+}
+
 func readAllMsgs(t require.TestingT, bk *brokertest.Broker, spec *pb.JournalSpec) (out []testMsg) {
 	var rr = client.NewRetryReader(context.Background(), bk.Client(), pb.ReadRequest{Journal: spec.Name})
 	var r = NewReadUncommittedIter(rr, newTestMsg)


### PR DESCRIPTION
This is an experimental API to allow for publishing a message where the
content is not known until after the acknowledgement intents are needed.
This is a low level API to allow consumers a little more flexibility
when storing checkpoints in external systems, as Flow does for
materializations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/319)
<!-- Reviewable:end -->
