### PR TITLE
`shards unassign` command no longer stalls

### DIFF
--- a/consumer/shard_api.go
+++ b/consumer/shard_api.go
@@ -234,7 +234,9 @@ func ShardUnassign(ctx context.Context, srv *Service, req *pc.UnassignRequest) (
 	etcdResp, err := srv.Etcd.Txn(ctx).If(cmp...).Then(ops...).Commit()
 	if err != nil {
 		return resp, fmt.Errorf("executing etcd transaction: %w", err)
-	} else if etcdResp.Succeeded {
+	} else if !etcdResp.Succeeded {
+		resp.Status = pc.Status_ETCD_TRANSACTION_FAILED
+	} else if len(ops) != 0 {
 		// If we made changes, delay responding until we have read our own Etcd write.
 		err = state.KS.WaitForRevision(ctx, etcdResp.Header.Revision)
 	}


### PR DESCRIPTION
This fixes a bug which caused the shard supervisor to stall indefinitely. If it ran `shards unassign` and there was nothing to be unassigned, it would never increment the etcd revision with its transaction. Then when we waited to observe our changes as reflected by the etcd mod revision, we would end up waiting until the next arbitrary transaction to complete. Needless to say, this is not the desired behavior.

Also adds a timeout to the command more generally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/322)
<!-- Reviewable:end -->
