### PR TITLE
parse SSEKMSKeyId from store url and pass to store config

### DIFF
--- a/broker/fragment/store_s3.go
+++ b/broker/fragment/store_s3.go
@@ -41,6 +41,9 @@ type S3StoreConfig struct {
 	// SSE is the server-side encryption type to be applied (eg, "AES256").
 	// By default, encryption is not used.
 	SSE string
+	// SSEKMSKeyId specifies the ID for the AWS KMS symmetric customer managed key
+	// By default, not used.
+	SSEKMSKeyId string
 }
 
 type s3Backend struct {
@@ -127,6 +130,9 @@ func (s *s3Backend) Persist(ctx context.Context, ep *url.URL, spool Spool) error
 	}
 	if cfg.SSE != "" {
 		putObj.ServerSideEncryption = aws.String(cfg.SSE)
+	}
+	if cfg.SSEKMSKeyId != "" {
+		putObj.SSEKMSKeyId = aws.String(cfg.SSEKMSKeyId)
 	}
 	if spool.CompressionCodec == pb.CompressionCodec_GZIP_OFFLOAD_DECOMPRESSION {
 		putObj.ContentEncoding = aws.String("gzip")

--- a/broker/fragment/stores_test.go
+++ b/broker/fragment/stores_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"sort"
 	"testing"
@@ -122,6 +123,17 @@ func TestStoreInteractions(t *testing.T) {
 		func(f pb.Fragment) { panic("no fragments, not called") }))
 	require.NoError(t, List(ctx, fs, tstBar,
 		func(f pb.Fragment) { panic("not called") }))
+}
+
+func TestParseStoreArgsS3(t *testing.T) {
+	storeURL, _ := url.Parse("s3://bucket/prefix/?endpoint=https://s3.region.amazonaws.com&SSE=kms&SSEKMSKeyId=123")
+	var s3Cfg S3StoreConfig
+	parseStoreArgs(storeURL, &s3Cfg)
+	require.Equal(t, "bucket", storeURL.Host)
+	require.Equal(t, "prefix/", storeURL.Path[1:])
+	require.Equal(t, "https://s3.region.amazonaws.com", s3Cfg.Endpoint)
+	require.Equal(t, "kms", s3Cfg.SSE)
+	require.Equal(t, "123", s3Cfg.SSEKMSKeyId)
 }
 
 func readFrag(t *testing.T, f pb.Fragment) string {


### PR DESCRIPTION
Adds in support for `SSEKMSKeyId` by parsing it from the store url and passing it into the `S3StoreConfig`. Done analogously to the `SSE` paramater.

Also added a unit test for `parseStoreArgs` which checks that the `SSEKMSKeyId` field (amongst others) is correctly parsed from the store URL

Additional Testing:

- Ran `TestStoreInteractions` using `SSE` and `SSEKMSKeyId` parameters on a bucket with SSE KMS + key. Used this structure as the fragment store:  `s3://bucket-with-kms-key/?find=rwFind&replace=rwReplace&endpoint=https://region.amazonaws.com&sse=aws:kms&ssekmskeyid=test-key")` where  `test-key` matched the one on `bucket-with-kms-key`. The test ran successfully and was able to `Persist, List, Open/Read, and Delete` objects from the bucket. 

- With the above setup, I removed the deletion portion of the test so that the encrypted objects would remain in the bucket. I then attempted through the CLI to call `get-objects`, once with a role without permissions to decrypt the objects and once with a role with permission to decrypt the objects. (*Note the kms key does not actually need to be passed in, rather the role calling the endpoint needs to have permissions to decrypt the object ([source](https://aws.amazon.com/premiumsupport/knowledge-center/decrypt-kms-encrypted-objects-s3/))). 
The result for the role without decryption perms was:
`An error occurred (AccessDenied) when calling the GetObject operation: The ciphertext refers to a customer master key that does not exist, does not exist in this region, or you are not allowed to access. ` 
And the result for the role with decryption perms was a successful download.
This is in evidence of the `Persist` correctly using the `SSEKMSKeyId` passed in from the fragment store to authorize decryption

 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/323)
<!-- Reviewable:end -->
