### PR TITLE
consumer: synchronously fail if StartCommit returns a pre-resolved error

### DIFF
--- a/consumer/shard_test.go
+++ b/consumer/shard_test.go
@@ -217,7 +217,7 @@ func TestShardStoreStartCommitFails(t *testing.T) {
 
 	runTransaction(tf, res.Shard, map[string]string{"foo": "bar"})
 
-	require.Equal(t, "runTransactions: store.StartCommit: an error",
+	require.Equal(t, "runTransactions: txnStartCommit: store.StartCommit: an error",
 		expectStatusCode(t, tf.state, pc.ReplicaStatus_FAILED).Errors[0])
 
 	tf.allocateShard(spec) // Cleanup.


### PR DESCRIPTION
This ensures txnRun fails-fast if StartCommit returns an error. If we don't do this, then txnStep will race a select over the shard's `readCh` with a select of the (failed) OpFuture, and then go on to call ConsumeMessage of a shard which is already in a failing state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/329)
<!-- Reviewable:end -->
