### PR TITLE
error when s3 client is missing region config

### DIFF
--- a/broker/fragment/store_s3.go
+++ b/broker/fragment/store_s3.go
@@ -234,10 +234,18 @@ func (s *s3Backend) s3Client(ep *url.URL) (cfg S3StoreConfig, client *s3.S3, err
 		return
 	}
 
+	// The aws sdk will always just return an error if this Region is not set, even if
+	// the Endpoint was provided explicitly. It's important to return an error here
+	// in that case, before adding this client to the `clients` map.
+	if awsSession.Config.Region == nil || *awsSession.Config.Region == "" {
+		err = fmt.Errorf("missing AWS region configuration for profile %q", cfg.Profile)
+		return
+	}
+
 	log.WithFields(log.Fields{
 		"endpoint":     cfg.Endpoint,
 		"profile":      cfg.Profile,
-		"region":       awsSession.Config.Region,
+		"region":       *awsSession.Config.Region,
 		"keyID":        creds.AccessKeyID,
 		"providerName": creds.ProviderName,
 	}).Info("constructed new aws.Session")


### PR DESCRIPTION
When the `region` configuration is missing the AWS S3 client will fail essentially all operations. This is true even if the `endpoint` is provided in the storage URL. Because the client is cached, this same failure will continue to happen, even _after_ you update `~/.aws/config` to set the `region`.

This commit adds an explicit check for the `Region` when initializing a new S3 client, to prevent the invalid client configuration from being persisted in the `clients` map.

This is not urgent or blocking, but I just wanted to get the fix in while I was thinking about it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/330)
<!-- Reviewable:end -->
