### PR TITLE
Fix keyspace missing watch events

### DIFF
--- a/kustomize/bases/etcd/etcd-bootstrap.sh
+++ b/kustomize/bases/etcd/etcd-bootstrap.sh
@@ -14,7 +14,7 @@ for i in $(seq 0 $((MIN_REPLICAS - 1))); do
 done
 
 # Re-joining after failure?
-if [ -e /var/run/etcd/default.etcd ]; then
+if [ -f /var/run/etcd/member_id ]; then
   echo "Re-joining etcd member"
   member_id=$(cat /var/run/etcd/member_id)
 


### PR DESCRIPTION
Fixes #337

It turns out that our assumptions about etcd watch responses weren't quite right. We had assumed that the `Header.Revision` would be the same as the highest `ModRevision` of the events within the response. While this happens to normally be the case, it is not guaranteed, and the revisions can differ significantly when the system is under heavy load. So we'd process a watch response that has a `Header.Revision` of `n`, but the most recent `ModRevision` of the contained `Events` was less than `n`. Then there's a subsequent watch response that _also_ has a `Header.Revision` of `n` that contains the remainder of the events up through revision `n`. But that second response gets ignored because the keyspace thinks it's already processed up through revision `n`.

This commit changes the way we process watch responses so that we only update the high water mark based on the `ModRevision` of the events, rather than just looking at the header. As a special case, we still use the `Header.Revision` when the response represents a progress notification, which has no inner events.

This also changes the keyspace to allow it to process the same revision multiple times. This was needed because when we re-start a watch, we now start at the last revision that's known to have been processed. The previous behavior was to always add 1 to the last known revision. So if events for a large transaction (which would all have the same `ModRevision`) get split over multiple watch responses, we should process them just fine.

I tested this locally by running the crash tests with the stream-sum example. I also tested by manually creating ~1k journals and then re-starting the brokers to trigger a bunch of watch events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/336)
<!-- Reviewable:end -->
