### PR TITLE
keyspace: update MemberId/RaftTerm on watch events

### DIFF
--- a/keyspace/key_space.go
+++ b/keyspace/key_space.go
@@ -303,6 +303,9 @@ func (ks *KeySpace) Apply(responses ...clientv3.WatchResponse) error {
 				lastRevision, firstRevision)
 		} else {
 			nextHeader.Revision = lastRevision
+			// If MemberId or RaftTerm have changed, it would have already been logged by `checkHeader`.
+			nextHeader.MemberId = wr.Header.MemberId
+			nextHeader.RaftTerm = wr.Header.RaftTerm
 		}
 
 		// Order on key, while preserving relative ModRevision order of events of the same key.


### PR DESCRIPTION
When processing watch events, update the persisted MemberId and RaftTerm. The `checkHeader` function logs any changes to these fields, as it's useful information for debugging. The last round of keyspace changes introduced a bug where we were no longer updating those fields if they changed after the initial keyspace load. This resulted in logging a warning on every subsequent watch event. This commit fixes that so that we once again only log on the first observation of the change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/338)
<!-- Reviewable:end -->
