### PR TITLE
consumer: add Shard.PrimaryLoop() client.OpFuture

### DIFF
--- a/consumer/interfaces.go
+++ b/consumer/interfaces.go
@@ -71,6 +71,13 @@ type Shard interface {
 	// includes only journals written to since this Shard was assigned to
 	// this process.
 	Progress() (readThrough, publishAt pb.Offsets)
+	// PrimaryLoop returns an OpFuture corresponding to this Shard
+	// assignment's primary processing loop.
+	// The returned future will resolve with the primary loop's returned error
+	// upon its exit. This will often be context.Cancelled, or a wrapped instance
+	// thereof, and the caller is responsible for detecting errors due to cancellation
+	// vs other kinds of processing errors.
+	PrimaryLoop() client.OpFuture
 }
 
 // Store is a durable and transactional storage backend used to persist arbitrary

--- a/consumer/shard.go
+++ b/consumer/shard.go
@@ -120,6 +120,8 @@ func newShard(svc *Service, item keyspace.KeyValue) *shard {
 func (s *shard) Context() context.Context                 { return s.ctx }
 func (s *shard) FQN() string                              { return s.resolved.fqn }
 func (s *shard) JournalClient() client.AsyncJournalClient { return s.ajc }
+func (s *shard) RecoveredHints() *pc.GetHintsResponse     { return s.recovery.hints }
+func (s *shard) PrimaryLoop() client.OpFuture             { return s.primary }
 
 func (s *shard) Spec() *pc.ShardSpec {
 	s.resolved.RLock()
@@ -139,10 +141,6 @@ func (s *shard) Progress() (readThrough, publishAt pb.Offsets) {
 	s.progress.Lock()
 	defer s.progress.Unlock()
 	return s.progress.readThrough.Copy(), s.progress.publishAt.Copy()
-}
-
-func (s *shard) RecoveredHints() *pc.GetHintsResponse {
-	return s.recovery.hints
 }
 
 // transition is called by Resolver with the current ShardSpec and allocator


### PR DESCRIPTION
Expose the status of the shard's primary processing loop to those who might care.

This allows applications to reliably detect when a shard has failed, and is a more reliable mechanism than the BeginFinisher interface because that interface is only called in the context of a current consumer transaction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/339)
<!-- Reviewable:end -->
