### PR TITLE
shard unassign: handle non-PRIMARY assignments which are FAILED

### DIFF
--- a/cmd/gazctl/gazctlcmd/shards_unassign.go
+++ b/cmd/gazctl/gazctlcmd/shards_unassign.go
@@ -38,24 +38,47 @@ func (cmd *cmdShardsUnassign) Execute([]string) (err error) {
 	if listResp.Status != pc.Status_OK {
 		return fmt.Errorf("unexpected listShard status: %v", listResp.Status.String())
 	}
-
 	var client = pc.NewShardClient(ShardsCfg.Consumer.MustDial(ctx))
 
-	unassignResp, err := client.Unassign(pb.WithDispatchDefault(ctx), &pc.UnassignRequest{
-		Shards:     shardIds(listResp.Shards),
-		OnlyFailed: cmd.Failed,
-		DryRun:     cmd.DryRun,
-	})
-	if err != nil {
-		return fmt.Errorf("unassigning shard: %w", err)
-	} else if err := unassignResp.Validate(); err != nil {
-		return fmt.Errorf("invalid response: %w", err)
+	// Compute the set of shard IDs which should have assignments removed.
+	var shardIDs []pc.ShardID
+
+	for _, shard := range listResp.Shards {
+		var isFailed bool
+		for _, status := range shard.Status {
+			if status.Code == pc.ReplicaStatus_FAILED {
+				isFailed = true
+			}
+		}
+		if !cmd.Failed || isFailed {
+			shardIDs = append(shardIDs, shard.Spec.Id)
+		}
 	}
 
-	if len(unassignResp.Shards) == 0 {
-		log.Warn("No shards assignments were modified. Use `shards list -l SELECTOR` to test your selector.")
-	} else {
-		for _, shardId := range unassignResp.Shards {
+	// Walk the set of filtered shards in batches.
+	for {
+		var chunk = len(shardIDs)
+
+		if chunk == 0 {
+			break
+		} else if chunk > 100 {
+			chunk = 100
+		}
+
+		var resp, err = client.Unassign(pb.WithDispatchDefault(ctx), &pc.UnassignRequest{
+			Shards:     shardIDs[:chunk],
+			OnlyFailed: cmd.Failed,
+			DryRun:     cmd.DryRun,
+		})
+		shardIDs = shardIDs[chunk:]
+
+		if err != nil {
+			return fmt.Errorf("unassigning shard: %w", err)
+		} else if err := resp.Validate(); err != nil {
+			return fmt.Errorf("invalid response: %w", err)
+		}
+
+		for _, shardId := range resp.Shards {
 			for _, origShard := range listResp.Shards {
 				if shardId == origShard.Spec.Id {
 					log.Infof("Successfully unassigned shard: id=%v. Previous status=%v, previous route members=%v", origShard.Spec.Id.String(), origShard.Status, origShard.Route.Members)
@@ -65,14 +88,4 @@ func (cmd *cmdShardsUnassign) Execute([]string) (err error) {
 	}
 
 	return nil
-}
-
-func shardIds(shards []pc.ListResponse_Shard) []pc.ShardID {
-	var ids []pc.ShardID
-
-	for _, shard := range shards {
-		ids = append(ids, shard.Spec.Id)
-	}
-
-	return ids
 }

--- a/consumer/shard_api_test.go
+++ b/consumer/shard_api_test.go
@@ -439,7 +439,8 @@ func TestAPIUnassignCases(t *testing.T) {
 	tf.setReplicaStatus(specB, remoteID, 0, pc.ReplicaStatus_PRIMARY)
 	tf.allocateShard(specC, localID, remoteID)
 	tf.setReplicaStatus(specC, localID, 0, pc.ReplicaStatus_PRIMARY)
-	tf.setReplicaStatus(specC, remoteID, 1, pc.ReplicaStatus_STANDBY)
+	tf.setReplicaStatus(specC, remoteID, 1, pc.ReplicaStatus_FAILED)
+	tf.setReplicaStatus(specC, remoteID, 2, pc.ReplicaStatus_STANDBY)
 	expectStatusCode(t, tf.state, pc.ReplicaStatus_PRIMARY)
 
 	// Asserts that we have modified the assignment as we expected.
@@ -458,17 +459,17 @@ func TestAPIUnassignCases(t *testing.T) {
 		}
 	}
 
-	// Case: A shard with no prior assignments
+	// Case: A shard with no assignments
 	resp, err := tf.service.Unassign(context.Background(), &pc.UnassignRequest{Shards: []pc.ShardID{specA.Id}})
-	require.Error(t, err, errNoAssignmentFound)
+	require.NoError(t, err)
 	check(resp, specA, []pc.ShardID{}, []pc.ReplicaStatus{})
 
-	// Case: A shard with a single assignment
+	// Case: A shard with a single PRIMARY assignment
 	resp, err = tf.service.Unassign(context.Background(), &pc.UnassignRequest{Shards: []pc.ShardID{specB.Id}})
 	require.NoError(t, err)
 	check(resp, specB, []pc.ShardID{specB.Id}, []pc.ReplicaStatus{})
 
-	// Case: A shard with multiple assignments
+	// Case: A shard with multiple assignments. PRIMARY is removed, FAILED is removed, STANDBY remains.
 	resp, err = tf.service.Unassign(context.Background(), &pc.UnassignRequest{Shards: []pc.ShardID{specC.Id}})
 	require.NoError(t, err)
 	check(resp, specC, []pc.ShardID{specC.Id}, []pc.ReplicaStatus{{Code: pc.ReplicaStatus_STANDBY}})
@@ -492,7 +493,7 @@ func TestAPIUnassignCases(t *testing.T) {
 	tf.setReplicaStatus(specB, localID, 0, pc.ReplicaStatus_FAILED)
 	tf.allocateShard(specC, localID)
 	tf.setReplicaStatus(specC, localID, 0, pc.ReplicaStatus_PRIMARY)
-	resp, err = tf.service.Unassign(context.Background(), &pc.UnassignRequest{Shards: []pc.ShardID{specA.Id, specB.Id}, OnlyFailed: true})
+	resp, err = tf.service.Unassign(context.Background(), &pc.UnassignRequest{Shards: []pc.ShardID{specA.Id, specB.Id, specC.Id}, OnlyFailed: true})
 	require.NoError(t, err)
 	check(resp, specA, []pc.ShardID{specA.Id, specB.Id}, []pc.ReplicaStatus{})
 	check(resp, specB, []pc.ShardID{specA.Id, specB.Id}, []pc.ReplicaStatus{})


### PR DESCRIPTION
The API should remove assignments which are non-PRIMARY but are also FAILED.

Also update `gazctl` to process selected shards in batches, so that each RPC is of bounded size and under the Etcd transaction size limit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/343)
<!-- Reviewable:end -->
