### PR TITLE
Fix azure pre-signed urls

### DIFF
--- a/broker/fragment/store_azure.go
+++ b/broker/fragment/store_azure.go
@@ -82,7 +82,7 @@ func (a *azureBackend) SignGet(ep *url.URL, fragment pb.Fragment, d time.Duratio
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/%s/%s?%s", cfg.containerURL(), cfg.prefix, blobName, sasQueryParams.Encode()), nil
+	return fmt.Sprintf("%s/%s?%s", cfg.containerURL(), blobName, sasQueryParams.Encode()), nil
 }
 
 func (a *azureBackend) Exists(ctx context.Context, ep *url.URL, fragment pb.Fragment) (bool, error) {


### PR DESCRIPTION
Azure URL signing was broken. The journal prefix was being duplicated in the URL, which resulted in unusable URLs. Clients would fail with a 403 response when attempting to fetch the fragment.  This removes the extra prefix to hopefully allow signing to work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/344)
<!-- Reviewable:end -->
