### PR TITLE
Phil/recoverylog pruning

### DIFF
--- a/consumer/recovery.go
+++ b/consumer/recovery.go
@@ -77,10 +77,10 @@ func fetchHints(ctx context.Context, spec *pc.ShardSpec, etcd *clientv3.Client) 
 	return
 }
 
-// pickFirstHints retrieves the first hints from |hints|.
+// PickFirstHints retrieves the first hints from |hints|.
 // If there are no primary hints available the most recent backup hints will be returned.
 // If there are no hints available an empty set of hints is returned.
-func pickFirstHints(hints *pc.GetHintsResponse, log pb.Journal) recoverylog.FSMHints {
+func PickFirstHints(hints *pc.GetHintsResponse, log pb.Journal) recoverylog.FSMHints {
 	if hints.PrimaryHints.Hints != nil {
 		return *hints.PrimaryHints.Hints
 	}
@@ -208,7 +208,7 @@ func beginRecovery(s *shard) error {
 	if err != nil {
 		return fmt.Errorf("GetHints: %w", err)
 	}
-	var pickedHints = pickFirstHints(s.recovery.hints, s.recovery.log)
+	var pickedHints = PickFirstHints(s.recovery.hints, s.recovery.log)
 
 	// Verify the |pickedHints| recovery log exists, and is of the correct Content-Type.
 	if logSpec, err := client.GetJournal(s.ctx, s.ajc, pickedHints.Log); err != nil {

--- a/consumer/shard_api_test.go
+++ b/consumer/shard_api_test.go
@@ -271,7 +271,7 @@ func TestAPIHintsCases(t *testing.T) {
 		BackupHints:  []pc.GetHintsResponse_ResponseHints{{}, {}},
 	}, resp)
 	// Picking hints passes through the supplied shard recovery log.
-	require.Equal(t, recoverylog.FSMHints{Log: "a/log"}, pickFirstHints(resp, "a/log"))
+	require.Equal(t, recoverylog.FSMHints{Log: "a/log"}, PickFirstHints(resp, "a/log"))
 
 	// Now allocate the shard, and then install hint fixtures.
 	tf.allocateShard(spec, localID)
@@ -310,7 +310,7 @@ func TestAPIHintsCases(t *testing.T) {
 		PrimaryHints: expected[0],
 		BackupHints:  expected[1:],
 	}, resp)
-	require.Equal(t, *expected[0].Hints, pickFirstHints(resp, "a/log"))
+	require.Equal(t, *expected[0].Hints, PickFirstHints(resp, "a/log"))
 
 	// Case: No primary hints
 	_, _ = tf.etcd.Delete(shard.ctx, spec.HintPrimaryKey())
@@ -322,7 +322,7 @@ func TestAPIHintsCases(t *testing.T) {
 		PrimaryHints: pc.GetHintsResponse_ResponseHints{},
 		BackupHints:  expected[1:],
 	}, resp)
-	require.Equal(t, *expected[1].Hints, pickFirstHints(resp, "a/log"))
+	require.Equal(t, *expected[1].Hints, PickFirstHints(resp, "a/log"))
 
 	// Case: Hint key has not yet been written to
 	require.NoError(t, storeRecordedHints(shard, mkHints(111)))


### PR DESCRIPTION
Fixes a couple of issues in `gazctl` subcommands regarding missing FSM hints for recovery logs.
See individual commit messages.

I tested these both as best I could manually, but there's still no automated tests for them AFAIK. Here's the scenarios I tested, and please feel free to suggest any others you can think of:

Recover:
- Run `shards recover` on a few active Flow shards from production

Recover 2:
- Setup a Flow capture shard and ingest some documents
- Disable the shard
- Run `shards recover --dir a`
- Delete the primary hints from etcd
- Run `shards recover --dir b` and `diff` to confirm it's the same as `a` (previously, this would have errored)
- Delete the backup hints from etcd
- Run `shards recover --dir c` and `diff` to confirm it's the same as `a`

Prune:
- Ran a few `--dry-run` commands against Flow's combustible-cronut environment
- Spot checked some of the 600+ journals that were skipped due to missing hints to confirm that they were indeed missing live nodes or hints
- Spot checked some of the journals that had been pruned to ensure that their shards all had hints
- Ran `--dry-run -l estuary.dev/task-type=derivation` and got:
    - `bytesKept=4606810948793 bytesPruned=26377008674102 bytesTotal=30983819622895 fragmentsKept=17359 fragmentsPruned=102500 fragmentsTotal=119859 shardsTotal=114 skippedJournals=2`
- Ran `--dry-run -l estuary.dev/task-type=materialization` and got:
    - `bytesKept=37440051630 bytesPruned=536165477654 bytesTotal=573605529284 fragmentsKept=3503 fragmentsPruned=9307 fragmentsTotal=12810 shardsTotal=291 skippedJournals=61`
- Ran `--dry-run -l estuary.dev/task-type=capture` and got:
    - `bytesKept=1529386200947 bytesPruned=14368880429210 bytesTotal=15898266630157 fragmentsKept=7896 fragmentsPruned=77030 fragmentsTotal=84926 shardsTotal=512 skippedJournals=56`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/347)
<!-- Reviewable:end -->
