### PR TITLE
gazctl: re-use shard and journal clients

### DIFF
--- a/cmd/gazctl/gazctlcmd/journals_list.go
+++ b/cmd/gazctl/gazctlcmd/journals_list.go
@@ -51,7 +51,9 @@ exactly equivalent to the original JournalSpecs.
 func (cmd *cmdJournalsList) Execute([]string) error {
 	startup(JournalsCfg.BaseConfig)
 
-	var resp = listJournals(cmd.Selector)
+	var ctx = context.Background()
+	var rjc = JournalsCfg.Broker.MustRoutedJournalClient(ctx)
+	var resp = listJournals(rjc, cmd.Selector)
 
 	switch cmd.Format {
 	case "table":
@@ -135,7 +137,7 @@ func (cmd *cmdJournalsList) outputYAML(resp *pb.ListResponse) {
 	writeHoistedJournalSpecTree(os.Stdout, resp)
 }
 
-func listJournals(s string) *pb.ListResponse {
+func listJournals(journalClient pb.JournalClient, s string) *pb.ListResponse {
 	var err error
 	var req pb.ListRequest
 	var ctx = context.Background()
@@ -143,7 +145,7 @@ func listJournals(s string) *pb.ListResponse {
 	req.Selector, err = pb.ParseLabelSelector(s)
 	mbp.Must(err, "failed to parse label selector", "selector", s)
 
-	resp, err := client.ListAllJournals(ctx, JournalsCfg.Broker.MustJournalClient(ctx), req)
+	resp, err := client.ListAllJournals(ctx, journalClient, req)
 	mbp.Must(err, "failed to list journals")
 
 	return resp

--- a/cmd/gazctl/gazctlcmd/journals_prune.go
+++ b/cmd/gazctl/gazctlcmd/journals_prune.go
@@ -28,8 +28,10 @@ See "journals list --help" for details and examples.
 
 func (cmd *cmdJournalsPrune) Execute([]string) error {
 	startup(JournalsCfg.BaseConfig)
+	var ctx = context.Background()
+	var rjc = JournalsCfg.Broker.MustRoutedJournalClient(ctx)
 
-	var resp = listJournals(cmd.Selector)
+	var resp = listJournals(rjc, cmd.Selector)
 	if len(resp.Journals) == 0 {
 		log.WithField("selector", cmd.Selector).Panic("no journals match selector")
 	}


### PR DESCRIPTION
This fixes an old bug in `shards prune` where it failed to use the `--broker.address` argument when creating the client.

In addition, this cleans up most of the places where gazctl subcommands were creating multiple new clients for a single operation, and consolidates down to a single client of each type per program invocation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/348)
<!-- Reviewable:end -->
