### PR TITLE
gazctl: shard pruning should consider all hints

### DIFF
--- a/cmd/gazctl/gazctlcmd/shards_recover.go
+++ b/cmd/gazctl/gazctlcmd/shards_recover.go
@@ -64,6 +64,8 @@ func (cmd *cmdShardsRecover) Execute([]string) error {
 	})
 	mbp.Must(err, "failed to fetch hints for shard")
 
+	log.WithField("hints", hintResp).Debug("fetched shard recovery hints")
+
 	var recoveryLog = shardResp.Shards[0].Spec.RecoveryLog()
 	var hints = consumer.PickFirstHints(hintResp, recoveryLog)
 	var rjc = ShardsCfg.Broker.MustRoutedJournalClient(ctx)

--- a/consumer/recovery.go
+++ b/consumer/recovery.go
@@ -283,7 +283,10 @@ func completeRecovery(s *shard) (_ pc.Checkpoint, err error) {
 		return cp, errors.WithMessage(err, "store.RestoreCheckpoint")
 	}
 
-	// Store |recoveredHints| as a backup.
+	// Store |recoveredHints| as a backup. We do this _after_ restoring the
+	// checkpoint as a sanity check, so that any integrity issues encountered
+	// during checkpoint recovery are surfaced before we over-write backup hints.
+	//
 	// For some workflows, the recoveredHints.Log may not equal our own log,
 	// in which case we omit this step.
 	// For example, Flow's shard split workflow instruments GetHints to

--- a/consumer/recoverylog/playback.go
+++ b/consumer/recoverylog/playback.go
@@ -306,6 +306,17 @@ func playLog(ctx context.Context, hints FSMHints, dir string, ajc client.AsyncJo
 				readLog = segment.Log
 				offset = reader.seek(segment.Log, segment.FirstOffset)
 				readThrough = barriers[segment.Log].Response().Commit.End
+
+				log.WithFields(log.Fields{
+					"log":         readLog,
+					"offset":      offset,
+					"firstOffset": segment.FirstOffset,
+					"firstSeqNo":  segment.FirstSeqNo,
+					"lastOffset":  segment.LastOffset,
+					"lastSeqNo":   segment.LastSeqNo,
+					"readThrough": readThrough,
+				}).Debug("seeking to next hinted segment")
+
 			} else if offset >= readThrough {
 				// We've read through |readThrough|, but still have not read all hinted log segments.
 				err = errors.Errorf("offset %v:%d >= readThrough %d, but FSM has unused hints; possible data loss",


### PR DESCRIPTION
If a shard is in a persistent state where it immediately becomes FAILED after recovery, it's very possible for the oldest recovered backup hints to actually be _newer_ than primary hints.

Then, if we prune without considering the primary hints, the shard is unable to recover from its log.

Fortunately this is easily remedied -- delete the primary hints while leaving backup recovery hints in place -- but better to not do it in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/350)
<!-- Reviewable:end -->
