### PR TITLE
recoverylog: relax FSM to allow updating the content of a property

### DIFF
--- a/consumer/recoverylog/fsm.go
+++ b/consumer/recoverylog/fsm.go
@@ -301,8 +301,6 @@ func (m *FSM) applyWrite(op *RecordedOp) error {
 func (m *FSM) applyProperty(op *Property) error {
 	if _, ok := m.Links[op.Path]; ok {
 		return ErrLinkExists
-	} else if content, ok := m.Properties[op.Path]; ok && content != op.Content {
-		return ErrPropertyExists
 	}
 	if m.Properties == nil {
 		m.Properties = make(map[string]string)

--- a/consumer/recoverylog/fsm_test.go
+++ b/consumer/recoverylog/fsm_test.go
@@ -383,14 +383,11 @@ func (s *FSMSuite) TestPropertyUpdates(c *gc.C) {
 	// Attempting a property update of an existing file fails.
 	c.Check(s.property(44, 0xf11e2261, 100, "/a/path", "bad"), gc.Equals, ErrLinkExists)
 
-	// Attempting a property update of an existing property fails. We may change
-	// this in the future, if a sufficient motivating case appears, but for now
-	// we apply the most restrictive behavior.
-	c.Check(s.property(44, 0xf11e2261, 100, "/a/property", "update"), gc.Equals,
-		ErrPropertyExists)
+	// An existing property may be updated.
+	c.Check(s.property(44, 0xf11e2261, 100, "/a/property", "update"), gc.IsNil)
 
 	c.Check(s.fsm.Properties, gc.DeepEquals, map[string]string{
-		"/a/property":       "content",
+		"/a/property":       "update",
 		"/another/property": "other-content",
 	})
 }


### PR DESCRIPTION
In certain situations, if a RocksDB doesn't fully initialize then it may re-create its IDENTITY file upon the next next open attempt.

Currently this is prohibited by FSM but should be relaxed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/356)
<!-- Reviewable:end -->
