### PR TITLE
broker/client: discard async appends of deleted journals

### DIFF
--- a/broker/client/append_service_test.go
+++ b/broker/client/append_service_test.go
@@ -66,6 +66,17 @@ func (s *AppendServiceSuite) TestBasicAppendWithRetry(c *gc.C) {
 	aaNext.mu.Unlock()
 
 	c.Check(as.PendingExcept(""), gc.HasLen, 0)
+
+	// Case: broker responds with JOURNAL_NOT_FOUND.
+	aa = as.StartAppend(pb.AppendRequest{Journal: "a/journal"}, nil)
+	_, _ = aa.Writer().WriteString("hello, world")
+	c.Assert(aa.Release(), gc.IsNil)
+
+	readHelloWorldAppendRequest(c, broker) // RPC is dispatched to broker.
+	broker.AppendRespCh <- buildNotFoundFixture(broker)
+
+	c.Check(aa.Err(), gc.IsNil)
+	c.Check(aa.Response().Status, gc.DeepEquals, pb.Status_JOURNAL_NOT_FOUND)
 }
 
 func (s *AppendServiceSuite) TestAppendPipelineWithAborts(c *gc.C) {
@@ -608,6 +619,13 @@ func buildAppendResponseFixture(ep interface{ Endpoint() pb.Endpoint }) pb.Appen
 			CompressionCodec: pb.CompressionCodec_NONE,
 		},
 		Registers: new(pb.LabelSet),
+	}
+}
+
+func buildNotFoundFixture(ep interface{ Endpoint() pb.Endpoint }) pb.AppendResponse {
+	return pb.AppendResponse{
+		Status: pb.Status_JOURNAL_NOT_FOUND,
+		Header: *buildHeaderFixture(ep),
 	}
 }
 

--- a/broker/client/appender.go
+++ b/broker/client/appender.go
@@ -96,6 +96,8 @@ func (a *Appender) Close() (err error) {
 		switch a.Response.Status {
 		case pb.Status_OK:
 			// Pass.
+		case pb.Status_JOURNAL_NOT_FOUND:
+			err = ErrJournalNotFound
 		case pb.Status_NOT_JOURNAL_PRIMARY_BROKER:
 			err = ErrNotJournalPrimaryBroker
 		case pb.Status_WRONG_APPEND_OFFSET:

--- a/broker/client/appender_test.go
+++ b/broker/client/appender_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	gc "gopkg.in/check.v1"
 	pb "go.gazette.dev/core/broker/protocol"
 	"go.gazette.dev/core/broker/teststub"
+	gc "gopkg.in/check.v1"
 )
 
 type AppenderSuite struct{}
@@ -124,6 +124,17 @@ func (s *AppenderSuite) TestBrokerCommitError(c *gc.C) {
 			},
 			errRe:       `validating broker response: Commit.Journal: invalid length .*`,
 			cachedRoute: 0,
+		},
+		// Case: known error status (journal not found).
+		{
+			finish: func() {
+				broker.AppendRespCh <- pb.AppendResponse{
+					Status: pb.Status_JOURNAL_NOT_FOUND,
+					Header: *buildHeaderFixture(broker),
+				}
+			},
+			errVal:      ErrJournalNotFound,
+			cachedRoute: 1,
 		},
 		// Case: known error status (not primary broker).
 		{


### PR DESCRIPTION
There are unavoidable scenarios where a client creates an intention to asynchronously write to a journal (as an AsyncAppend, or an checkpointed ACK intent), but the journal is deleted before the write can land.

Before, AppendService will loop forever awaiting the journal to come back into existence.

After, AppendService will discard writes to deleted or non-existant journals, logging a warning before doing so. This parallels the broker behavior of dropping spooled fragment data upon journal deletion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/357)
<!-- Reviewable:end -->
