### PR TITLE
take two: relax ErrJournalNotFound only when writing recovered ACKs

### DIFF
--- a/broker/client/append_service.go
+++ b/broker/client/append_service.go
@@ -19,7 +19,8 @@ import (
 // pipelined and batched to amortize the cost of broker Append RPCs. It may
 // also simplify implementations for clients who would prefer to simply have
 // writes block until successfully committed, as opposed to handling errors
-// and retries themselves.
+// and retries themselves. AppendService will retry all errors except for
+// context cancellation and ErrJournalNotFound.
 //
 // For each journal, AppendService manages an ordered list of AsyncAppends,
 // each having buffered content to be appended. The list is dispatched in
@@ -278,7 +279,8 @@ func (p *AsyncAppend) Writer() *bufio.Writer { return p.fb.buf }
 // also roll back any writes queued by the caller, aborting the append
 // transaction. Require is valid for use only until Release is called.
 // Require returns itself, allowing uses like:
-//      Require(maybeErrors()).Release()
+//
+//	Require(maybeErrors()).Release()
 func (p *AsyncAppend) Require(err error) *AsyncAppend {
 	if err != nil && p.op.err == nil {
 		p.op.err = err
@@ -392,7 +394,7 @@ var serveAppends = func(s *AppendService, aa *AsyncAppend, err error) {
 						err2 = aa.app.Close()
 					}
 
-					if err2 == context.Canceled || err2 == context.DeadlineExceeded {
+					if err2 == context.Canceled || err2 == context.DeadlineExceeded || err2 == ErrJournalNotFound {
 						err = err2
 						return nil // Break retry loop.
 					} else if err2 != nil {

--- a/broker/client/append_service.go
+++ b/broker/client/append_service.go
@@ -21,12 +21,6 @@ import (
 // writes block until successfully committed, as opposed to handling errors
 // and retries themselves.
 //
-// AppendService will retry all errors except for context cancellation and
-// ErrJournalNotFound. Appends to journals which don't exist are not treated
-// as hard errors, as there are scenarios where clients cannot prevent a raced
-// deletion of a journal. Instead, the append is discarded and callers can
-// inspect its response Status.
-//
 // For each journal, AppendService manages an ordered list of AsyncAppends,
 // each having buffered content to be appended. The list is dispatched in
 // FIFO order by a journal-specific goroutine.
@@ -284,8 +278,7 @@ func (p *AsyncAppend) Writer() *bufio.Writer { return p.fb.buf }
 // also roll back any writes queued by the caller, aborting the append
 // transaction. Require is valid for use only until Release is called.
 // Require returns itself, allowing uses like:
-//
-//	Require(maybeErrors()).Release()
+//      Require(maybeErrors()).Release()
 func (p *AsyncAppend) Require(err error) *AsyncAppend {
 	if err != nil && p.op.err == nil {
 		p.op.err = err
@@ -402,10 +395,6 @@ var serveAppends = func(s *AppendService, aa *AsyncAppend, err error) {
 					if err2 == context.Canceled || err2 == context.DeadlineExceeded {
 						err = err2
 						return nil // Break retry loop.
-					} else if err2 == ErrJournalNotFound {
-						log.WithField("journal", aa.app.Request.Journal).
-							Warn("discarding append for journal that does not exist")
-						return nil // Success; break loop.
 					} else if err2 != nil {
 						aa.app.Reset()
 						return err2 // Retry by returning |err2|.

--- a/broker/client/append_service_test.go
+++ b/broker/client/append_service_test.go
@@ -66,17 +66,6 @@ func (s *AppendServiceSuite) TestBasicAppendWithRetry(c *gc.C) {
 	aaNext.mu.Unlock()
 
 	c.Check(as.PendingExcept(""), gc.HasLen, 0)
-
-	// Case: broker responds with JOURNAL_NOT_FOUND.
-	aa = as.StartAppend(pb.AppendRequest{Journal: "a/journal"}, nil)
-	_, _ = aa.Writer().WriteString("hello, world")
-	c.Assert(aa.Release(), gc.IsNil)
-
-	readHelloWorldAppendRequest(c, broker) // RPC is dispatched to broker.
-	broker.AppendRespCh <- buildNotFoundFixture(broker)
-
-	c.Check(aa.Err(), gc.IsNil)
-	c.Check(aa.Response().Status, gc.DeepEquals, pb.Status_JOURNAL_NOT_FOUND)
 }
 
 func (s *AppendServiceSuite) TestAppendPipelineWithAborts(c *gc.C) {
@@ -619,13 +608,6 @@ func buildAppendResponseFixture(ep interface{ Endpoint() pb.Endpoint }) pb.Appen
 			CompressionCodec: pb.CompressionCodec_NONE,
 		},
 		Registers: new(pb.LabelSet),
-	}
-}
-
-func buildNotFoundFixture(ep interface{ Endpoint() pb.Endpoint }) pb.AppendResponse {
-	return pb.AppendResponse{
-		Status: pb.Status_JOURNAL_NOT_FOUND,
-		Header: *buildHeaderFixture(ep),
 	}
 }
 

--- a/broker/client/appender.go
+++ b/broker/client/appender.go
@@ -96,8 +96,6 @@ func (a *Appender) Close() (err error) {
 		switch a.Response.Status {
 		case pb.Status_OK:
 			// Pass.
-		case pb.Status_JOURNAL_NOT_FOUND:
-			err = ErrJournalNotFound
 		case pb.Status_NOT_JOURNAL_PRIMARY_BROKER:
 			err = ErrNotJournalPrimaryBroker
 		case pb.Status_WRONG_APPEND_OFFSET:

--- a/broker/client/appender.go
+++ b/broker/client/appender.go
@@ -180,7 +180,7 @@ func Append(ctx context.Context, rjc pb.RoutedJournalClient, req pb.AppendReques
 			return a.Response, nil
 		} else if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
 			// Fallthrough to retry
-		} else if err == ErrNotJournalPrimaryBroker {
+		} else if err == ErrNotJournalPrimaryBroker || err == ErrInsufficientJournalBrokers {
 			// Fallthrough.
 		} else {
 			return a.Response, err

--- a/broker/client/appender.go
+++ b/broker/client/appender.go
@@ -96,6 +96,8 @@ func (a *Appender) Close() (err error) {
 		switch a.Response.Status {
 		case pb.Status_OK:
 			// Pass.
+		case pb.Status_JOURNAL_NOT_FOUND:
+			err = ErrJournalNotFound
 		case pb.Status_NOT_JOURNAL_PRIMARY_BROKER:
 			err = ErrNotJournalPrimaryBroker
 		case pb.Status_WRONG_APPEND_OFFSET:

--- a/broker/client/appender_test.go
+++ b/broker/client/appender_test.go
@@ -222,7 +222,7 @@ func (s *AppenderSuite) TestAppendCases(c *gc.C) {
 			{status: pb.Status_NOT_JOURNAL_PRIMARY_BROKER},
 			{status: pb.Status_OK},
 			// Case 2: Unexpected status is surfaced.
-			{status: pb.Status_INSUFFICIENT_JOURNAL_BROKERS},
+			{status: pb.Status_WRONG_APPEND_OFFSET},
 			// Case 3: As are errors.
 			{err: errors.New("an error")},
 		}
@@ -273,7 +273,7 @@ func (s *AppenderSuite) TestAppendCases(c *gc.C) {
 
 	// Case 2: Unexpected status is surfaced.
 	_, err = Append(ctx, rjc, pb.AppendRequest{Journal: "a/journal"}, con, tent)
-	c.Check(err, gc.ErrorMatches, "INSUFFICIENT_JOURNAL_BROKERS")
+	c.Check(err, gc.ErrorMatches, "WRONG_APPEND_OFFSET")
 
 	// Case 3: As are errors.
 	_, err = Append(ctx, rjc, pb.AppendRequest{Journal: "a/journal"}, con, tent)

--- a/broker/client/appender_test.go
+++ b/broker/client/appender_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	gc "gopkg.in/check.v1"
 	pb "go.gazette.dev/core/broker/protocol"
 	"go.gazette.dev/core/broker/teststub"
+	gc "gopkg.in/check.v1"
 )
 
 type AppenderSuite struct{}
@@ -124,6 +124,17 @@ func (s *AppenderSuite) TestBrokerCommitError(c *gc.C) {
 			},
 			errRe:       `validating broker response: Commit.Journal: invalid length .*`,
 			cachedRoute: 0,
+		},
+		// Case: known error status (journal not found).
+		{
+			finish: func() {
+				broker.AppendRespCh <- pb.AppendResponse{
+					Status: pb.Status_JOURNAL_NOT_FOUND,
+					Header: *buildHeaderFixture(broker),
+				}
+			},
+			errVal:      ErrJournalNotFound,
+			cachedRoute: 1,
 		},
 		// Case: known error status (not primary broker).
 		{

--- a/broker/client/appender_test.go
+++ b/broker/client/appender_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
+	gc "gopkg.in/check.v1"
 	pb "go.gazette.dev/core/broker/protocol"
 	"go.gazette.dev/core/broker/teststub"
-	gc "gopkg.in/check.v1"
 )
 
 type AppenderSuite struct{}
@@ -124,17 +124,6 @@ func (s *AppenderSuite) TestBrokerCommitError(c *gc.C) {
 			},
 			errRe:       `validating broker response: Commit.Journal: invalid length .*`,
 			cachedRoute: 0,
-		},
-		// Case: known error status (journal not found).
-		{
-			finish: func() {
-				broker.AppendRespCh <- pb.AppendResponse{
-					Status: pb.Status_JOURNAL_NOT_FOUND,
-					Header: *buildHeaderFixture(broker),
-				}
-			},
-			errVal:      ErrJournalNotFound,
-			cachedRoute: 1,
 		},
 		// Case: known error status (not primary broker).
 		{

--- a/consumer/transaction_test.go
+++ b/consumer/transaction_test.go
@@ -651,6 +651,8 @@ func TestRunTxnsACKsRecoveredCheckpoint(t *testing.T) {
 	var cp = playAndComplete(t, shard)
 	cp.AckIntents = map[pb.Journal][]byte{
 		echoOut.Name: []byte(`{"Key": "recovered fixture"}` + "\n"),
+		// Recovered ACK intents may included journals which do not exist.
+		"does/not/exist": []byte(`{"Key": "discarded fixture"}` + "\n"),
 	}
 
 	// Use a read channel fixture which immediately closes.


### PR DESCRIPTION
* Revert prior commit.
* Make ErrJournalNotFound a terminal error for AppendService, because it's essentially never recoverable and should be retried at a higher level.
* Have client.Appender handle insufficient journal brokers, as this _is_ a retry-able case that happens.
* Update consumer to relax the writes of recovered ACK intents. Log a missing journal but allow the session to proceed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/358)
<!-- Reviewable:end -->
