### PR TITLE
Phil/pruning is hard

### DIFF
--- a/cmd/gazctl/gazctlcmd/shards_prune.go
+++ b/cmd/gazctl/gazctlcmd/shards_prune.go
@@ -152,8 +152,11 @@ func foldHintsIntoSegments(hints recoverylog.FSMHints, sets map[pb.Journal]recov
 	for _, segment := range segments {
 		var set = sets[segment.Log]
 
-		// If FirstSeqNo is equal, set.Add will replace a zero LastOffset with a
-		// non-zero one (which is not what we want in this case).
+		// set.Add() will return an error if we attempt to add a segment having a
+		// greater SeqNo and LastOffset != 0, to a set already having a lesser
+		// SeqNo and LastOffset == 0. Or, if FirstSeqNo is equal, it will replace
+		// a zero LastOffset with a non-zero one (which is not what we want
+		// in this case).
 		//
 		// So, zero LastOffset here if |segment| isn't strictly less than
 		// and non-overlapping with a pre-existing last LastOffset==0 element.

--- a/cmd/gazctl/gazctlcmd/shards_prune_test.go
+++ b/cmd/gazctl/gazctlcmd/shards_prune_test.go
@@ -1,12 +1,294 @@
 package gazctlcmd
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	pb "go.gazette.dev/core/broker/protocol"
+	pc "go.gazette.dev/core/consumer/protocol"
 	"go.gazette.dev/core/consumer/recoverylog"
 )
+
+func TestFragmentsAreRetainedWhenAnyHintsRequireThem(t *testing.T) {
+	// The goal is to allow a shard to recover using any of the persisted
+	// hints. In order for that to work, all fragments that come after the final
+	// hinted segment of _any_ hints must be retained. In this case, the primary
+	// hints are quite old. So we test a fragment that would otherwise be elidgable
+	// for pruning, and assert that it is retained due to coming after the segment
+	// in the primary hints.
+	var fixture = `{
+    "header": {
+      "process_id": {
+        "zone": "us-central1-c",
+        "suffix": "flow-reactor-74fcd7f9db-n5c5j"
+      },
+      "route": {
+        "members": null,
+        "primary": -1
+      },
+      "etcd": {
+        "cluster_id": 9261053468663690000,
+        "member_id": 14358579373743376000,
+        "revision": 57121751,
+        "raft_term": 140
+      }
+    },
+    "primary_hints": {
+      "hints": {
+        "log": "example/log",
+        "live_nodes": [
+          {
+            "fnode": 1018,
+            "segments": [
+              {
+                "author": 3418428788,
+                "first_seq_no": 1018,
+                "first_offset": 129100,
+                "first_checksum": 2628272215,
+                "last_seq_no": 1024
+              }
+            ]
+          }
+        ],
+        "properties": null
+      }
+    },
+    "backup_hints": [
+      {
+        "hints": {
+          "log": "example/log",
+          "live_nodes": [
+            {
+              "fnode": 1109,
+              "segments": [
+                {
+                  "author": 3418428788,
+                  "first_seq_no": 1109,
+                  "first_offset": 140706,
+                  "first_checksum": 1095500179,
+                  "last_seq_no": 1115,
+                  "last_offset": 141535
+                }
+              ]
+            },
+            {
+              "fnode": 1289,
+              "segments": [
+                {
+                  "author": 2080950356,
+                  "first_seq_no": 1289,
+                  "first_offset": 152255,
+                  "first_checksum": 777889612,
+                  "last_seq_no": 1290,
+                  "last_offset": 153297
+                }
+              ]
+            },
+            {
+              "fnode": 1642,
+              "segments": [
+                {
+                  "author": 245017003,
+                  "first_seq_no": 1642,
+                  "first_offset": 245137,
+                  "first_checksum": 3605342194,
+                  "last_seq_no": 1645,
+                  "last_offset": 251592
+                }
+              ]
+            },
+            {
+              "fnode": 1657,
+              "segments": [
+                {
+                  "author": 3711033845,
+                  "first_seq_no": 1657,
+                  "first_offset": 252114,
+                  "first_checksum": 794580610,
+                  "last_seq_no": 1660,
+                  "last_offset": 252379
+                }
+              ]
+            },
+            {
+              "fnode": 1661,
+              "segments": [
+                {
+                  "author": 3711033845,
+                  "first_seq_no": 1661,
+                  "first_offset": 252379,
+                  "first_checksum": 157414297,
+                  "last_seq_no": 1665,
+                  "last_offset": 252574
+                }
+              ]
+            },
+            {
+              "fnode": 1666,
+              "segments": [
+                {
+                  "author": 3711033845,
+                  "first_seq_no": 1666,
+                  "first_offset": 252574,
+                  "first_checksum": 157986885,
+                  "last_seq_no": 1666,
+                  "last_offset": 252610
+                }
+              ]
+            },
+            {
+              "fnode": 1670,
+              "segments": [
+                {
+                  "author": 3711033845,
+                  "first_seq_no": 1670,
+                  "first_offset": 252737,
+                  "first_checksum": 1747582972,
+                  "last_seq_no": 1673,
+                  "last_offset": 259192
+                }
+              ]
+            }
+          ],
+          "properties": [
+            {
+              "path": "/IDENTITY",
+              "content": "0a4d4620-a93f-468a-9c12-26de543261f0\n"
+            }
+          ]
+        }
+      },
+      {
+        "hints": {
+          "log": "example/log",
+          "live_nodes": [
+            {
+              "fnode": 1109,
+              "segments": [
+                {
+                  "author": 3418428788,
+                  "first_seq_no": 1109,
+                  "first_offset": 140706,
+                  "first_checksum": 1095500179,
+                  "last_seq_no": 1115,
+                  "last_offset": 141535
+                }
+              ]
+            },
+            {
+              "fnode": 1289,
+              "segments": [
+                {
+                  "author": 2080950356,
+                  "first_seq_no": 1289,
+                  "first_offset": 152255,
+                  "first_checksum": 777889612,
+                  "last_seq_no": 1290,
+                  "last_offset": 153297
+                }
+              ]
+            },
+            {
+              "fnode": 1614,
+              "segments": [
+                {
+                  "author": 1701696287,
+                  "first_seq_no": 1614,
+                  "first_offset": 237537,
+                  "first_checksum": 3210869242,
+                  "last_seq_no": 1617,
+                  "last_offset": 243992
+                }
+              ]
+            },
+            {
+              "fnode": 1629,
+              "segments": [
+                {
+                  "author": 245017003,
+                  "first_seq_no": 1629,
+                  "first_offset": 244514,
+                  "first_checksum": 3153286517,
+                  "last_seq_no": 1632,
+                  "last_offset": 244779
+                }
+              ]
+            },
+            {
+              "fnode": 1633,
+              "segments": [
+                {
+                  "author": 245017003,
+                  "first_seq_no": 1633,
+                  "first_offset": 244779,
+                  "first_checksum": 3701750198,
+                  "last_seq_no": 1637,
+                  "last_offset": 244974
+                }
+              ]
+            },
+            {
+              "fnode": 1638,
+              "segments": [
+                {
+                  "author": 245017003,
+                  "first_seq_no": 1638,
+                  "first_offset": 244974,
+                  "first_checksum": 2949463732,
+                  "last_seq_no": 1638,
+                  "last_offset": 245010
+                }
+              ]
+            },
+            {
+              "fnode": 1642,
+              "segments": [
+                {
+                  "author": 245017003,
+                  "first_seq_no": 1642,
+                  "first_offset": 245137,
+                  "first_checksum": 3605342194,
+                  "last_seq_no": 1645,
+                  "last_offset": 251592
+                }
+              ]
+            }
+          ],
+          "properties": [
+            {
+              "path": "/IDENTITY",
+              "content": "0a4d4620-a93f-468a-9c12-26de543261f0\n"
+            }
+          ]
+        }
+      }
+    ]
+  }`
+
+	var resp pc.GetHintsResponse
+	require.NoError(t, json.Unmarshal([]byte(fixture), &resp))
+
+	var set = make(map[pb.Journal][]recoverylog.Segment)
+
+	for _, hints := range resp.BackupHints {
+		foldHintsIntoSegments(*hints.Hints, set)
+	}
+	// Assert that the fragment would be pruned if we only accounted for the backup hints
+	require.False(t, overlapsAnySegment(set["example/log"], pb.Fragment{
+		Journal: "example/log",
+		Begin:   243993,
+		End:     244000,
+	}))
+
+	// Now add the primary hints and assert that the fragment would be retained
+	foldHintsIntoSegments(*resp.PrimaryHints.Hints, set)
+	require.True(t, overlapsAnySegment(set["example/log"], pb.Fragment{
+		Journal: "example/log",
+		Begin:   243993,
+		End:     244000,
+	}))
+}
 
 func TestSegmentFoldingWithSingleLog(t *testing.T) {
 	var m = make(map[pb.Journal][]recoverylog.Segment)

--- a/cmd/gazctl/gazctlcmd/shards_prune_test.go
+++ b/cmd/gazctl/gazctlcmd/shards_prune_test.go
@@ -1,7 +1,6 @@
 package gazctlcmd
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,7 +9,7 @@ import (
 )
 
 func TestSegmentFoldingWithSingleLog(t *testing.T) {
-	var m = make(map[pb.Journal]recoverylog.SegmentSet)
+	var m = make(map[pb.Journal][]recoverylog.Segment)
 
 	foldHintsIntoSegments(recoverylog.FSMHints{
 		Log: "a/log",
@@ -28,7 +27,7 @@ func TestSegmentFoldingWithSingleLog(t *testing.T) {
 	}, m)
 
 	// Expect segments are merged and final LastOffset is zero'd.
-	require.Equal(t, map[pb.Journal]recoverylog.SegmentSet{
+	require.Equal(t, map[pb.Journal][]recoverylog.Segment{
 		"a/log": {
 			recoverylog.Segment{Author: 0x1, FirstSeqNo: 2, FirstOffset: 200, LastSeqNo: 9, LastOffset: 901, Log: "a/log"},
 			recoverylog.Segment{Author: 0x2, FirstSeqNo: 25, FirstOffset: 2500, LastSeqNo: 27, LastOffset: 0, Log: "a/log"},
@@ -54,13 +53,13 @@ func TestSegmentFoldingWithSingleLog(t *testing.T) {
 	}, m)
 
 	// Note that SegmentSet allows only a strict suffix of Segment to have a zero LastOffset.
-	require.Equal(t, map[pb.Journal]recoverylog.SegmentSet{
+	require.Equal(t, map[pb.Journal][]recoverylog.Segment{
 		"a/log": {
-			recoverylog.Segment{Author: 0x1, FirstSeqNo: 2, FirstOffset: 200, LastSeqNo: 12, LastOffset: 1201, Log: "a/log"},
-			recoverylog.Segment{Author: 0x2, FirstSeqNo: 15, FirstOffset: 1500, LastSeqNo: 16, LastOffset: 1601, Log: "a/log"},
-			recoverylog.Segment{Author: 0x2, FirstSeqNo: 20, FirstOffset: 2000, LastSeqNo: 20, LastOffset: 0, Log: "a/log"},
-			recoverylog.Segment{Author: 0x2, FirstSeqNo: 25, FirstOffset: 2500, LastSeqNo: 27, LastOffset: 0, Log: "a/log"},
-		},
+			{Author: 0x1, FirstSeqNo: 2, FirstOffset: 200, LastSeqNo: 9, LastOffset: 901, Log: "a/log"},
+			{Author: 0x2, FirstSeqNo: 25, FirstOffset: 2500, LastSeqNo: 27, LastOffset: 0, Log: "a/log"},
+			{Author: 0x1, FirstSeqNo: 10, FirstOffset: 1000, LastSeqNo: 12, LastOffset: 1201, Log: "a/log"},
+			{Author: 0x2, FirstSeqNo: 15, FirstOffset: 1500, LastSeqNo: 16, LastOffset: 1601, Log: "a/log"},
+			{Author: 0x2, FirstSeqNo: 20, FirstOffset: 2000, LastSeqNo: 20, LastOffset: 0, Log: "a/log"}},
 	}, m)
 
 	// Final hints have later final segments.
@@ -81,30 +80,54 @@ func TestSegmentFoldingWithSingleLog(t *testing.T) {
 	}, m)
 
 	// Note that SegmentSet allows only a strict suffix of Segment to have a zero LastOffset.
-	require.Equal(t, map[pb.Journal]recoverylog.SegmentSet{
+	require.Equal(t, map[pb.Journal][]recoverylog.Segment{
 		"a/log": {
-			recoverylog.Segment{Author: 0x1, FirstSeqNo: 2, FirstOffset: 200, LastSeqNo: 12, LastOffset: 1201, Log: "a/log"},
-			recoverylog.Segment{Author: 0x2, FirstSeqNo: 14, FirstOffset: 1400, LastSeqNo: 16, LastOffset: 1601, Log: "a/log"},
-			recoverylog.Segment{Author: 0x2, FirstSeqNo: 20, FirstOffset: 2000, LastSeqNo: 20, LastOffset: 0, Log: "a/log"},
-			recoverylog.Segment{Author: 0x2, FirstSeqNo: 25, FirstOffset: 2500, LastSeqNo: 27, LastOffset: 0, Log: "a/log"},
-			recoverylog.Segment{Author: 0x2, FirstSeqNo: 34, FirstOffset: 3400, LastSeqNo: 36, LastOffset: 0, Log: "a/log"},
+			{Author: 0x1, FirstSeqNo: 2, FirstOffset: 200, LastSeqNo: 9, LastOffset: 901, Log: "a/log"},
+			{Author: 0x2, FirstSeqNo: 25, FirstOffset: 2500, LastSeqNo: 27, LastOffset: 0, Log: "a/log"},
+			{Author: 0x1, FirstSeqNo: 10, FirstOffset: 1000, LastSeqNo: 12, LastOffset: 1201, Log: "a/log"},
+			{Author: 0x2, FirstSeqNo: 15, FirstOffset: 1500, LastSeqNo: 16, LastOffset: 1601, Log: "a/log"},
+			{Author: 0x2, FirstSeqNo: 20, FirstOffset: 2000, LastSeqNo: 20, LastOffset: 0, Log: "a/log"},
+			{Author: 0x2, FirstSeqNo: 14, FirstOffset: 1400, LastSeqNo: 15, LastOffset: 1500, Log: "a/log"},
+			{Author: 0x2, FirstSeqNo: 25, FirstOffset: 2500, LastSeqNo: 27, LastOffset: 2700, Log: "a/log"},
+			{Author: 0x2, FirstSeqNo: 34, FirstOffset: 3400, LastSeqNo: 36, LastOffset: 0, Log: "a/log"},
 		},
 	}, m)
 
-	require.Empty(t, m["a/log"].Intersect("a/log", 0, 200)) // May be pruned.
-	require.NotEmpty(t, m["a/log"].Intersect("a/log", 0, 300))
-	require.NotEmpty(t, m["a/log"].Intersect("a/log", 1200, 1300))
-	require.Empty(t, m["a/log"].Intersect("a/log", 1201, 1400))
-	require.Empty(t, m["a/log"].Intersect("a/log", 1601, 2000))
+	require.False(t, overlapsAnySegment(m["a/log"], pb.Fragment{Begin: 0, End: 200}))
+	require.True(t, overlapsAnySegment(m["a/log"], pb.Fragment{Begin: 0, End: 300}))
+	require.True(t, overlapsAnySegment(m["a/log"], pb.Fragment{Begin: 1200, End: 1300}))
+	require.False(t, overlapsAnySegment(m["a/log"], pb.Fragment{Begin: 1201, End: 1400}))
+	require.False(t, overlapsAnySegment(m["a/log"], pb.Fragment{Begin: 1601, End: 2000}))
 
 	// Any range intersecting the LastOffset==0 tail of the set is always overlapping (and not pruned).
-	require.NotEmpty(t, m["a/log"].Intersect("a/log", 1601, 2001))
-	require.NotEmpty(t, m["a/log"].Intersect("a/log", 2100, 2200))
-	require.NotEmpty(t, m["a/log"].Intersect("a/log", 9998, 9999))
+	require.True(t, overlapsAnySegment(m["a/log"], pb.Fragment{Begin: 1601, End: 2001}))
+	require.True(t, overlapsAnySegment(m["a/log"], pb.Fragment{Begin: 2100, End: 2200}))
+	require.True(t, overlapsAnySegment(m["a/log"], pb.Fragment{Begin: 9998, End: 9999}))
+}
+
+func TestOverlapsAnySegment(t *testing.T) {
+	var segments = []recoverylog.Segment{
+		{FirstOffset: 50, LastOffset: 60},
+		{FirstOffset: 70, LastOffset: 80},
+		{FirstOffset: 90, LastOffset: 99},
+	}
+	require.True(t, overlapsAnySegment(segments, pb.Fragment{Begin: 0, End: 51}))
+	require.True(t, overlapsAnySegment(segments, pb.Fragment{Begin: 0, End: 999}))
+	require.True(t, overlapsAnySegment(segments, pb.Fragment{Begin: 98, End: 0}))
+	require.True(t, overlapsAnySegment(segments, pb.Fragment{Begin: 59, End: 60}))
+	require.True(t, overlapsAnySegment(segments, pb.Fragment{Begin: 65, End: 85}))
+
+	require.False(t, overlapsAnySegment(segments, pb.Fragment{Begin: 60, End: 70}))
+	require.False(t, overlapsAnySegment(segments, pb.Fragment{Begin: 0, End: 50}))
+	require.False(t, overlapsAnySegment(segments, pb.Fragment{Begin: 100, End: 99999}))
+
+	segments = append(segments, recoverylog.Segment{FirstOffset: 99, LastOffset: 0})
+	require.True(t, overlapsAnySegment(segments, pb.Fragment{Begin: 100, End: 99999}))
+	require.True(t, overlapsAnySegment(segments, pb.Fragment{Begin: 85, End: 99999}))
 }
 
 func TestSegmentFoldingWithManyLogs(t *testing.T) {
-	var m = make(map[pb.Journal]recoverylog.SegmentSet)
+	var m = make(map[pb.Journal][]recoverylog.Segment)
 
 	var fixtures = []recoverylog.FSMHints{
 		{
@@ -145,24 +168,23 @@ func TestSegmentFoldingWithManyLogs(t *testing.T) {
 		},
 	}
 
-	for _, h := range rand.Perm(len(fixtures)) {
-		foldHintsIntoSegments(fixtures[h], m)
+	for _, h := range fixtures {
+		foldHintsIntoSegments(h, m)
 	}
 
-	require.Equal(t, map[pb.Journal]recoverylog.SegmentSet{
-
+	require.Equal(t, map[pb.Journal][]recoverylog.Segment{
 		"l/one": {
-			recoverylog.Segment{Author: 0x20, FirstSeqNo: 20, FirstOffset: 20, LastSeqNo: 21, LastOffset: 21, Log: "l/one"},
-			recoverylog.Segment{Author: 0x30, FirstSeqNo: 30, FirstOffset: 30, LastSeqNo: 31, LastOffset: 31, Log: "l/one"},
-			recoverylog.Segment{Author: 0x40, FirstSeqNo: 40, FirstOffset: 40, LastSeqNo: 41, LastOffset: 41, Log: "l/one"},
-			recoverylog.Segment{Author: 0x70, FirstSeqNo: 70, FirstOffset: 70, LastSeqNo: 71, LastOffset: 0, Log: "l/one"},
+			{Author: 0x30, FirstSeqNo: 30, FirstOffset: 30, LastSeqNo: 31, LastOffset: 31, Log: "l/one"},
+			{Author: 0x70, FirstSeqNo: 70, FirstOffset: 70, LastSeqNo: 71, LastOffset: 0, Log: "l/one"},
+			{Author: 0x20, FirstSeqNo: 20, FirstOffset: 20, LastSeqNo: 21, LastOffset: 21, Log: "l/one"},
+			{Author: 0x40, FirstSeqNo: 40, FirstOffset: 40, LastSeqNo: 41, LastOffset: 41, Log: "l/one"},
 		},
 		"l/three": {
-			recoverylog.Segment{Author: 0x80, FirstSeqNo: 80, FirstOffset: 80, LastSeqNo: 81, LastOffset: 0, Log: "l/three"},
+			{Author: 0x80, FirstSeqNo: 80, FirstOffset: 80, LastSeqNo: 81, LastOffset: 0, Log: "l/three"},
 		},
 		"l/two": {
-			recoverylog.Segment{Author: 0x50, FirstSeqNo: 50, FirstOffset: 50, LastSeqNo: 51, LastOffset: 51, Log: "l/two"},
-			recoverylog.Segment{Author: 0x60, FirstSeqNo: 60, FirstOffset: 60, LastSeqNo: 61, LastOffset: 0, Log: "l/two"},
+			{Author: 0x60, FirstSeqNo: 60, FirstOffset: 60, LastSeqNo: 61, LastOffset: 0, Log: "l/two"},
+			{Author: 0x50, FirstSeqNo: 50, FirstOffset: 50, LastSeqNo: 51, LastOffset: 51, Log: "l/two"},
 		},
 	}, m)
 }

--- a/consumer/recoverylog/segment.go
+++ b/consumer/recoverylog/segment.go
@@ -141,6 +141,8 @@ func reduceSegment(a, b Segment) (Segment, error) {
 	// Offset ordering constraint checks.
 	case a.FirstSeqNo < b.FirstSeqNo && a.Log == b.Log && a.FirstOffset > b.FirstOffset:
 		return a, fmt.Errorf("expected monotonic FirstOffset: %#v vs %#v", a, b)
+	case a.FirstSeqNo < b.FirstSeqNo && a.LastOffset == 0 && b.LastOffset != 0:
+		return a, fmt.Errorf("expected preceding Segment to also include LastOffset: %#v vs %#v", a, b)
 
 	case a.LastOffset == 0 && a.Log != b.Log:
 		// This cases isn't strictly required, but it's true of the intended

--- a/consumer/recoverylog/segment_test.go
+++ b/consumer/recoverylog/segment_test.go
@@ -76,9 +76,9 @@ func (s *SegmentSuite) TestSegmentReductionCases(c *gc.C) {
 		},
 		// Overlap, and preceding Segment is missing LastOffset.
 		{
-			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 000, FirstChecksum: 0x22, Log: A},
-			b: Segment{Author: 0x1, FirstSeqNo: 4, LastSeqNo: 9, FirstOffset: 400, LastOffset: 901, FirstChecksum: 0x44, Log: A},
-			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 9, FirstOffset: 200, LastOffset: 901, FirstChecksum: 0x22, Log: A},
+			a:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 000, FirstChecksum: 0x22, Log: A},
+			b:   Segment{Author: 0x1, FirstSeqNo: 4, LastSeqNo: 9, FirstOffset: 400, LastOffset: 901, FirstChecksum: 0x44, Log: A},
+			err: "expected preceding Segment to also include LastOffset: .*",
 		},
 		// Overlap, mismatched authors.
 		{
@@ -97,12 +97,6 @@ func (s *SegmentSuite) TestSegmentReductionCases(c *gc.C) {
 			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22, Log: A},
 			b: Segment{Author: 0x1, FirstSeqNo: 3, LastSeqNo: 6, FirstOffset: 300, LastOffset: 000, FirstChecksum: 0x33, Log: A},
 			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22, Log: A},
-		},
-		// Covered, with 0 LastOffset
-		{
-			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22, Log: A},
-			b: Segment{Author: 0x1, FirstSeqNo: 1, LastSeqNo: 8, FirstOffset: 2, LastOffset: 0, FirstChecksum: 0x33, Log: A},
-			e: Segment{Author: 0x1, FirstSeqNo: 1, LastSeqNo: 8, FirstOffset: 2, LastOffset: 0, FirstChecksum: 0x33, Log: A},
 		},
 		// Disjoint.
 		{
@@ -127,12 +121,6 @@ func (s *SegmentSuite) TestSegmentReductionCases(c *gc.C) {
 			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22, Log: A},
 			b: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 9, FirstOffset: 210, LastOffset: 901, FirstChecksum: 0x22, Log: A},
 			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 9, FirstOffset: 210, LastOffset: 901, FirstChecksum: 0x22, Log: A},
-		},
-		// Equal-left, with LastOffset: 0
-		{
-			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22, Log: A},
-			b: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 9, FirstOffset: 200, LastOffset: 000, FirstChecksum: 0x22, Log: A},
-			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 9, FirstOffset: 200, LastOffset: 000, FirstChecksum: 0x22, Log: A},
 		},
 		// Equal-left, but checksum mismatch.
 		{
@@ -266,6 +254,9 @@ func (s *SegmentSuite) TestSetConsistencyChecks(c *gc.C) {
 		// Overlapping, incorrect log.
 		{Segment{Author: 0xa, FirstSeqNo: 4, LastSeqNo: 5, FirstOffset: 400, LastOffset: 501, Log: "wrong"},
 			"expected Segment Log equality: .*"},
+		// Missing LastOffset.
+		{Segment{Author: 0xb, FirstSeqNo: 12, LastSeqNo: 12, FirstOffset: 1200, LastOffset: 000, Log: A},
+			"expected preceding Segment to also include LastOffset: .*"},
 		// Non-monotonic offsets.
 		{Segment{Author: 0xb, FirstSeqNo: 12, LastSeqNo: 12, FirstOffset: 1050, LastOffset: 1200, Log: A},
 			"expected monotonic FirstOffset: .*"},


### PR DESCRIPTION
This reverts the previous attempt to fix recovery log pruning, and replaces it with a slightly different approach. Individual commit messages have more details, but the gist is to avoid trying to merge segment sets from different hints, and instead just check each set of hints separately.


One question I have is how to handle recovery logs that are used by multiple shards (that have since split). For example, say we have shards `a/0` and `a/1`, which both have hints covering `a/log`. As of this PR, we would still potentially be merging the hints from multiple shards into a single set, since the maps are keyed on journal name and hints name, and both shards will have hints with the same name. So I'm thinking it may be safer to key the hints on journal name and a combined shardId+hintsName (for example `"a/log": { "a/0-primary": <hints>, "a/1-primary": <hints>, ...}`). But I'm not really sure whether that's necessary, so curious to get your thoughts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/362)
<!-- Reviewable:end -->
