### PR TITLE
broker/fragment: region support for s3 stores

### DIFF
--- a/broker/fragment/stores_test.go
+++ b/broker/fragment/stores_test.go
@@ -126,7 +126,7 @@ func TestStoreInteractions(t *testing.T) {
 }
 
 func TestParseStoreArgsS3(t *testing.T) {
-	storeURL, _ := url.Parse("s3://bucket/prefix/?endpoint=https://s3.region.amazonaws.com&SSE=kms&SSEKMSKeyId=123")
+	storeURL, _ := url.Parse("s3://bucket/prefix/?endpoint=https://s3.region.amazonaws.com&SSE=kms&SSEKMSKeyId=123&region=some-region")
 	var s3Cfg S3StoreConfig
 	parseStoreArgs(storeURL, &s3Cfg)
 	require.Equal(t, "bucket", storeURL.Host)
@@ -134,6 +134,7 @@ func TestParseStoreArgsS3(t *testing.T) {
 	require.Equal(t, "https://s3.region.amazonaws.com", s3Cfg.Endpoint)
 	require.Equal(t, "kms", s3Cfg.SSE)
 	require.Equal(t, "123", s3Cfg.SSEKMSKeyId)
+	require.Equal(t, "some-region", s3Cfg.Region)
 }
 
 func readFrag(t *testing.T, f pb.Fragment) string {


### PR DESCRIPTION
Previously s3 stores could only use the region available via a given profile or the AWS application default credentials. This adds the ability to set an alternate region in the endpoint URL for an s3 fragment store for buckets that are in a different region.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/365)
<!-- Reviewable:end -->
