### PR TITLE
support optional TLS for etcd, brokers, and consumers

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   build:
     name: "Build"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2

--- a/broker/fragment/spool_unix.go
+++ b/broker/fragment/spool_unix.go
@@ -1,9 +1,8 @@
-// +build !windows
+//go:build !windows
 
 package fragment
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -14,8 +13,8 @@ import (
 // to the OS after an explicit call to Close, or if the os.File is garbage-
 // collected (such that the runtime finalizer calls Close on our behalf).
 var newSpoolFile = func() (File, error) {
-	if f, err := ioutil.TempFile("", "spool"); err != nil {
-		return f, err
+	if f, err := os.CreateTemp("", "spool"); err != nil {
+		return nil, err
 	} else {
 		return f, os.Remove(f.Name())
 	}

--- a/broker/fragment/spool_win.go
+++ b/broker/fragment/spool_win.go
@@ -1,9 +1,8 @@
-// +build windows
+//go:build windows
 
 package fragment
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -15,8 +14,8 @@ import (
 // behavior is used because Windows does not support removing the one-and-only
 // hard link of a currently-open file.
 var newSpoolFile = func() (File, error) {
-	if f, err := ioutil.TempFile("", "spool"); err != nil {
-		return f, err
+	if f, err := os.CreateTemp("", "spool"); err != nil {
+		return nil, err
 	} else {
 		runtime.SetFinalizer(f, removeFileFinalizer)
 		return f, nil

--- a/broker/protocol/endpoint.go
+++ b/broker/protocol/endpoint.go
@@ -8,8 +8,7 @@ import (
 // scheme defines the network transport and semantics of the host, path,
 // and query components. At present, supported schemes are:
 //
-//  * http://host(:port)/path?query
-//
+//   - http://host(:port)/path?query
 type Endpoint string
 
 // Validate returns an error if the Endpoint is not well-formed.
@@ -34,6 +33,10 @@ func (ep Endpoint) GRPCAddr() string {
 	var addr string
 	if u := ep.URL(); u.Scheme == "unix" {
 		addr = "unix://" + u.Path
+	} else if u.Port() == "" && u.Scheme == "https" {
+		addr = u.Host + ":443"
+	} else if u.Port() == "" && u.Scheme == "http" {
+		addr = u.Host + ":80"
 	} else {
 		addr = u.Host
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.gazette.dev/core
 
-go 1.19
+go 1.22
 
 require (
 	cloud.google.com/go/storage v1.30.1

--- a/go.sum
+++ b/go.sum
@@ -224,12 +224,14 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -689,6 +691,7 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
+golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/mainboilerplate/client.go
+++ b/mainboilerplate/client.go
@@ -10,20 +10,41 @@ import (
 	"go.gazette.dev/core/broker/client"
 	pb "go.gazette.dev/core/broker/protocol"
 	pc "go.gazette.dev/core/consumer/protocol"
+	"go.gazette.dev/core/server"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 // AddressConfig of a remote service.
 type AddressConfig struct {
-	Address pb.Endpoint `long:"address" env:"ADDRESS" default:"http://localhost:8080" description:"Service address endpoint"`
+	Address       pb.Endpoint `long:"address" env:"ADDRESS" default:"http://localhost:8080" description:"Service address endpoint"`
+	CertFile      string      `long:"cert-file" env:"CERT_FILE" default:"" description:"Path to the client TLS certificate"`
+	KeyFile       string      `long:"key-file" env:"KEY_FILE" default:"" description:"Path to the client TLS private key"`
+	TrustedCAFile string      `long:"trusted-ca-file" env:"TRUSTED_CA_FILE" default:"" description:"Path to the trusted CA for client verification of server certificates"`
 }
 
 // MustDial dials the server address using a protocol.Dispatcher balancer, and panics on error.
 func (c *AddressConfig) MustDial(ctx context.Context) *grpc.ClientConn {
-	var cc, err = grpc.DialContext(ctx,
+	var tc credentials.TransportCredentials
+
+	if c.Address.URL().Scheme == "https" {
+		var tlsConfig, err = server.BuildTLSConfig(c.CertFile, c.KeyFile, c.TrustedCAFile)
+		Must(err, "failed to build TLS config")
+		tc = credentials.NewTLS(tlsConfig)
+	} else {
+		tc = insecure.NewCredentials()
+	}
+
+	// Use a tighter bound for the maximum back-off delay (default is 120s).
+	var backoffConfig = backoff.DefaultConfig
+	backoffConfig.MaxDelay = 5 * time.Second
+
+	cc, err := grpc.DialContext(ctx,
 		c.Address.GRPCAddr(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(tc),
+		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoffConfig}),
 		// A single Gazette broker frequently serves LOTS of Journals.
 		// Readers will start many concurrent reads of various journals,
 		// but may process them in arbitrary orders, which means a journal
@@ -33,9 +54,6 @@ func (c *AddressConfig) MustDial(ctx context.Context) *grpc.ClientConn {
 		// only stream-level flow control.
 		grpc.WithInitialConnWindowSize(math.MaxInt32),
 		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, pb.DispatcherGRPCBalancerName)),
-		// Use a tighter bound for the maximum back-off delay (default is 120s).
-		// TODO(johnny): Make this configurable?
-		grpc.WithBackoffMaxDelay(time.Second*5),
 		// Instrument client for gRPC metric collection.
 		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),

--- a/mainboilerplate/etcd.go
+++ b/mainboilerplate/etcd.go
@@ -2,31 +2,50 @@ package mainboilerplate
 
 import (
 	"context"
+	"crypto/tls"
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.gazette.dev/core/broker/protocol"
+	"go.gazette.dev/core/server"
 	"google.golang.org/grpc"
 )
 
 // EtcdConfig configures the application Etcd session.
 type EtcdConfig struct {
-	Address  protocol.Endpoint `long:"address" env:"ADDRESS" default:"http://localhost:2379" description:"Etcd service address endpoint"`
-	LeaseTTL time.Duration     `long:"lease" env:"LEASE_TTL" default:"20s" description:"Time-to-live of Etcd lease"`
+	Address       protocol.Endpoint `long:"address" env:"ADDRESS" default:"http://localhost:2379" description:"Etcd service address endpoint"`
+	CertFile      string            `long:"cert-file" env:"CERT_FILE" default:"" description:"Path to the client TLS certificate"`
+	KeyFile       string            `long:"key-file" env:"KEY_FILE" default:"" description:"Path to the client TLS private key"`
+	TrustedCAFile string            `long:"trusted-ca-file" env:"TRUSTED_CA_FILE" default:"" description:"Path to the trusted CA for client verification of server certificates"`
+	LeaseTTL      time.Duration     `long:"lease" env:"LEASE_TTL" default:"20s" description:"Time-to-live of Etcd lease"`
 }
 
 // MustDial builds an Etcd client connection.
 func (c *EtcdConfig) MustDial() *clientv3.Client {
+	var addr = c.Address.URL()
+	var tlsConfig *tls.Config
+
+	switch addr.Scheme {
+	case "https":
+		var err error
+		tlsConfig, err = server.BuildTLSConfig(c.CertFile, c.KeyFile, c.TrustedCAFile)
+		Must(err, "failed to build TLS config")
+	case "unix":
+		// The Etcd client requires hostname is stripped from unix:// URLs.
+		addr.Host = ""
+	}
+
 	// Use a blocking dial to build a trial connection to Etcd. If we're actively
 	// partitioned or mis-configured this avoids a K8s CrashLoopBackoff, and
 	// there's nothing actionable to do anyway aside from wait (or be SIGTERM'd).
 	var timer = time.AfterFunc(time.Second, func() {
-		log.WithField("addr", c.Address).Warn("dialing Etcd is taking a while (is network okay?)")
+		log.WithField("addr", addr.String()).Warn("dialing Etcd is taking a while (is network okay?)")
 	})
-	var trialEtcd, err = clientv3.New(clientv3.Config{
-		Endpoints:   []string{string(c.Address)},
+	trialEtcd, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{addr.String()},
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		TLS:         tlsConfig,
 	})
 	Must(err, "failed to build trial Etcd client")
 
@@ -35,7 +54,7 @@ func (c *EtcdConfig) MustDial() *clientv3.Client {
 
 	// Build our actual |etcd| connection, with much tighter timeout bounds.
 	etcd, err := clientv3.New(clientv3.Config{
-		Endpoints: []string{string(c.Address)},
+		Endpoints: []string{addr.String()},
 		// Automatically and periodically sync the set of Etcd servers.
 		// If a network split occurs, this allows for attempting different
 		// members until a connectable one is found on our "side" of the network
@@ -48,6 +67,7 @@ func (c *EtcdConfig) MustDial() *clientv3.Client {
 		DialKeepAliveTimeout: c.LeaseTTL / 4,
 		// Require a reasonably recent server cluster.
 		RejectOldCluster: true,
+		TLS:              tlsConfig,
 	})
 	Must(err, "failed to build Etcd client")
 

--- a/mainboilerplate/service.go
+++ b/mainboilerplate/service.go
@@ -1,12 +1,6 @@
 package mainboilerplate
 
 import (
-	"fmt"
-	"math/rand"
-	"net"
-	"os"
-	"time"
-
 	petname "github.com/dustinkirkland/golang-petname"
 	"go.gazette.dev/core/broker/protocol"
 	"go.gazette.dev/core/server"
@@ -20,33 +14,25 @@ type ZoneConfig struct {
 // ServiceConfig represents identification and addressing configuration of the process.
 type ServiceConfig struct {
 	ZoneConfig
-	ID   string `long:"id" env:"ID" description:"Unique ID of this process. Auto-generated if not set"`
-	Host string `long:"host" env:"HOST" description:"Addressable, advertised hostname or IP of this process. Hostname is used if not set"`
-	Port string `long:"port" env:"PORT" description:"Service port for HTTP and gRPC requests. A random port is used if not set. Port may also take the form 'unix:///path/to/socket' to use a Unix Domain Socket"`
+	ID             string `long:"id" env:"ID" description:"Unique ID of this process. Auto-generated if not set"`
+	Host           string `long:"host" env:"HOST" description:"Addressable, advertised hostname or IP of this process. Hostname is used if not set"`
+	Port           string `long:"port" env:"PORT" description:"Service port for HTTP and gRPC requests. A random port is used if not set. Port may also take the form 'unix:///path/to/socket' to use a Unix Domain Socket"`
+	ServerCertFile string `long:"server-cert-file" env:"SERVER_CERT_FILE" default:"" description:"Path to the server TLS certificate. This option toggles whether TLS is used. If absent, all other TLS settings are ignored."`
+	ServerKeyFile  string `long:"server-key-file" env:"SERVER_KEY_FILE" default:"" description:"Path to the server TLS private key"`
+	ServerCAFile   string `long:"server-ca-file" env:"SERVER_CA_FILE" default:"" description:"Path to the trusted CA for server verification of client certificates. When present, client certificates are required and verified against this CA. When absent, client certificates are not required but are verified against the system CA pool if presented."`
+	PeerCertFile   string `long:"peer-cert-file" env:"PEER_CERT_FILE" default:"" description:"Path to the client TLS certificate for peer-to-peer requests"`
+	PeerKeyFile    string `long:"peer-key-file" env:"PEER_KEY_FILE" default:"" description:"Path to the client TLS private key for peer-to-peer requests"`
+	PeerCAFile     string `long:"peer-ca-file" env:"PEER_CA_FILE" default:"" description:"Path to the trusted CA for client verification of peer server certificates. When absent, the system CA pool is used instead."`
 }
 
 // ProcessSpec of the ServiceConfig.
 func (cfg ServiceConfig) BuildProcessSpec(srv *server.Server) protocol.ProcessSpec {
-	var err error
 	if cfg.ID == "" {
-		rand.Seed(time.Now().UnixNano()) // Seed generator for Generate's use.
 		cfg.ID = petname.Generate(2, "-")
-	}
-	if cfg.Host == "" {
-		cfg.Host, err = os.Hostname()
-		Must(err, "failed to determine hostname")
-	}
-
-	var endpoint string
-	switch addr := srv.RawListener.Addr().(type) {
-	case *net.TCPAddr:
-		endpoint = fmt.Sprintf("http://%s:%d", cfg.Host, addr.Port)
-	case *net.UnixAddr:
-		endpoint = fmt.Sprintf("%s://%s%s", addr.Net, cfg.Host, addr.Name)
 	}
 
 	return protocol.ProcessSpec{
 		Id:       protocol.ProcessSpec_ID{Zone: cfg.Zone, Suffix: cfg.ID},
-		Endpoint: protocol.Endpoint(endpoint),
+		Endpoint: srv.Endpoint(),
 	}
 }

--- a/mk/ci-builder.Dockerfile
+++ b/mk/ci-builder.Dockerfile
@@ -2,7 +2,7 @@
 # this file. This works only so long as there are no _other_ files that go into the final image.
 # So if you add any ADD or COPY directives, be sure to update the cache key in the github actions
 # workflow yaml
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update -y \
  && apt-get upgrade -y \
@@ -23,8 +23,8 @@ RUN apt-get update -y \
       zip \
  && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.19.13
-ARG GOLANG_SHA256=4643d4c29c55f53fa0349367d7f1bb5ca554ea6ef528c146825b0f8464e2e668
+ARG GOLANG_VERSION=1.22.4
+ARG GOLANG_SHA256=ba79d4526102575196273416239cca418a651e049c2b099f3159db85e7bade7d
 
 ARG DOCKER_VERSION=19.03.8
 ARG DOCKER_SHA256=7f4115dc6a3c19c917f8b9664d7b51c904def1c984e082c4600097433323cf6f

--- a/mk/ci-release.Dockerfile
+++ b/mk/ci-release.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Pick run-time library packages which match the development packages
 # used by the ci-builder image. "curl" is included, to allow node-zone.sh

--- a/server/server.go
+++ b/server/server.go
@@ -2,10 +2,14 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"time"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -15,6 +19,8 @@ import (
 	pb "go.gazette.dev/core/broker/protocol"
 	"go.gazette.dev/core/task"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -22,9 +28,9 @@ import (
 // socket (using CMux). Additional protocols may be added to the Server by
 // interacting directly with its provided CMux.
 type Server struct {
-	// RawListener is the bound listener of the Server.
-	RawListener net.Listener
-	// CMux wraps RawListener to provide connection protocol multiplexing over
+	// Advertised Endpoint of this Server.
+	endpoint pb.Endpoint
+	// CMux wraps a listener to provide connection protocol multiplexing over
 	// a single bound socket. gRPC and HTTP Listeners are provided by default.
 	// Additional Listeners may be added directly via CMux.Match() -- though
 	// it is then the user's responsibility to Serve the resulting Listeners.
@@ -43,37 +49,65 @@ type Server struct {
 	httpServer http.Server
 }
 
-// New builds and returns a Server of the given TCP network interface |iface|
-// and |port|. |port| may be empty, in which case a random free port is assigned.
-func New(iface string, port string) (*Server, error) {
-	var network, addr string
+// New builds and returns a Server of the given TCP network interface `iface`
+// and `port` for serving traffic directed at `host`.
+// `port` may be empty, in which case a random free port is assigned.
+// if `tlsConfig` is non-nil, the Server uses TLS (and is otherwise in the clear).
+func New(iface, host, port string, serverTLS, peerTLS *tls.Config) (*Server, error) {
+	var network, bind string
 	if port == "" {
-		network, addr = "tcp", fmt.Sprintf("%s:0", iface) // Assign a random free port.
+		network, bind = "tcp", fmt.Sprintf("%s:0", iface) // Assign a random free port.
 	} else if u, err := url.Parse(port); err == nil && u.Scheme == "unix" {
-		network, addr = "unix", u.Path
+		network, bind = "unix", u.Path
+
+		// Ignore TLS for UDS. It's already local, and clients cannot use the
+		// advertised endpoint scheme to determine whether to expect TLS.
+		serverTLS, peerTLS = nil, nil
 	} else {
-		network, addr = "tcp", fmt.Sprintf("%s:%s", iface, port)
+		network, bind = "tcp", fmt.Sprintf("%s:%s", iface, port)
 	}
 
-	var raw, err = net.Listen(network, addr)
+	var listener, err = net.Listen(network, bind)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to bind service address (%s)", addr)
+		return nil, errors.Wrapf(err, "failed to bind service address (%s)", bind)
 	}
-	return NewFromListener(raw)
-}
 
-// NewFromListener builds a new Server using the provided Listener, which can be customized by the
-// caller. This is intended to support servers wishing to use TLS.
-func NewFromListener(listener net.Listener) (*Server, error) {
+	// If no host was specified, use the hostname.
+	if host == "" {
+		if host, err = os.Hostname(); err != nil {
+			return nil, err
+		}
+	}
+	// If no port was specified, query the dynamic port which we bound.
+	if port == "" {
+		port = strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	}
+
+	var endpoint string
+	if network == "unix" {
+		endpoint = fmt.Sprintf("unix://%s%s", host, bind)
+	} else {
+		endpoint = fmt.Sprintf("://%s:%s", host, port)
+
+		if serverTLS != nil {
+			endpoint = "https" + endpoint
+		} else {
+			endpoint = "http" + endpoint
+		}
+	}
+
 	var srv = &Server{
-		HTTPMux: http.DefaultServeMux,
+		endpoint: pb.Endpoint(endpoint),
+		HTTPMux:  http.DefaultServeMux,
 		GRPCServer: grpc.NewServer(
 			grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 			grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 		),
-		RawListener: listener,
 	}
-	srv.CMux = cmux.New(srv.RawListener)
+	if serverTLS != nil {
+		listener = tls.NewListener(listener, serverTLS)
+	}
+	srv.CMux = cmux.New(listener)
 
 	srv.CMux.HandleError(func(err error) bool {
 		if _, ok := err.(net.Error); !ok {
@@ -94,19 +128,28 @@ func NewFromListener(listener net.Listener) (*Server, error) {
 	srv.GRPCListener = srv.CMux.MatchWithWriters(
 		cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 
-	var err error
+	var tc credentials.TransportCredentials
+	if peerTLS == nil {
+		tc = insecure.NewCredentials()
+	} else {
+		tc = credentials.NewTLS(peerTLS)
+	}
+
+	// This grpc.ClientConn connects to this server's loopback, and also
+	// to peer server addresses via the dispatch balancer. It has particular
+	// knowledge of what addresses *should* be reach-able (from Etcd
+	// advertisements). Use an aggressive back-off for server-to-server
+	// connections, as it's crucial for quick cluster recovery from
+	// partitions, etc.
+	var backoffConfig = backoff.DefaultConfig
+	backoffConfig.MaxDelay = time.Millisecond * 500
+
 	srv.GRPCLoopback, err = grpc.DialContext(
 		context.Background(),
-		srv.RawListener.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		srv.endpoint.GRPCAddr(),
+		grpc.WithTransportCredentials(tc),
+		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoffConfig}),
 		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, pb.DispatcherGRPCBalancerName)),
-		// This grpc.ClientConn connects to this server's loopback, and also
-		// to peer server addresses via the dispatch balancer. It has particular
-		// knowledge of what addresses *should* be reach-able (from Etcd
-		// advertisements). Use an aggressive back-off for server-to-server
-		// connections, as it's crucial for quick cluster recovery from
-		// partitions, etc.
-		grpc.WithBackoffMaxDelay(time.Millisecond*500),
 		// Instrument client for gRPC metric collection.
 		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
@@ -122,10 +165,43 @@ func NewFromListener(listener net.Listener) (*Server, error) {
 	return srv, nil
 }
 
+func BuildTLSConfig(certPath, keyPath, trustedCAPath string) (*tls.Config, error) {
+	var tlsConfig = &tls.Config{
+		ClientAuth: tls.VerifyClientCertIfGiven,
+	}
+
+	// Load a presented certificate and key.
+	if certPath != "" {
+		var cert, err = tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load certificate and key: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	// Load a trusted Certificate Authority, which is required for clients.
+	if trustedCAPath != "" {
+		caCert, err := os.ReadFile(trustedCAPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+		}
+
+		var caCertPool = x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to append CA certificate to pool")
+		}
+		tlsConfig.ClientCAs = caCertPool
+		tlsConfig.RootCAs = caCertPool
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return tlsConfig, nil
+}
+
 // MustLoopback builds and returns a new Server instance bound to a random
 // port on the loopback interface. It panics on error.
 func MustLoopback() *Server {
-	if srv, err := New("127.0.0.1", ""); err != nil {
+	if srv, err := New("127.0.0.1", "127.0.0.1", "", nil, nil); err != nil {
 		log.WithField("err", err).Panic("failed to build Server")
 		panic("not reached")
 	} else {
@@ -135,7 +211,7 @@ func MustLoopback() *Server {
 
 // Endpoint of the Server.
 func (s *Server) Endpoint() pb.Endpoint {
-	return pb.Endpoint("http://" + s.RawListener.Addr().String())
+	return s.endpoint
 }
 
 // QueueTasks serving the CMux, HTTP, and gRPC component servers onto the task.Group.


### PR DESCRIPTION
The approach closely parallels the Etcd certificate authorization
model and can support mutual (client and server) certificate
verification.

In server contexts, for $foo (of broker, consumer):

--foo.server-cert-file / FOO_SERVER_CERT_FILE is a path to a cerificate
  for the server to present to clients.

  This option toggles whether TLS is used. If absent, all other TLS
  settings are ignored.

--foo.server-key-file / FOO_SERVER_KEY_FILE is the corresponding private key.

--foo.server-ca-file / FOO_SERVER_CA_FILE is a trusted certificate authority
  for verification of client certificates.

  If this option is omitted, client certificates are verified if
  presented but are not required.

  If this option is set, client certificates are required and verified.

--foo.peer-cert-file / FOO_PEER_CERT_FILE is a path to a cerificate
  for the server to present to peers in a peer-to-peer client context.

--foo.peer-key-file / FOO_PEER_KEY_FILE is the corresponding private key.

--foo.peer-ca-file / FOO_PEER_CA_FILE is a trusted certificate authority
  for verification of peer server certificates. If not specified,
  the system CA pool is used instead.

In client contexts, for $foo (of etcd, broker, consumer):

--foo.cert-file / FOO_CERT_FILE is a path to a client cerificate to
  present to the server context.

--foo.key-file / FOO_KEY_FILE is the corresponding private key.

--foo.trusted-ca-file / FOO_TRUSTED_CA_FILE is a trusted certificate authority
  for verification of server certificates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/384)
<!-- Reviewable:end -->
