### PR TITLE
fix: Add missing endian conversion macros to enable MacOS builds

### DIFF
--- a/consumer/store-sqlite/store.cpp
+++ b/consumer/store-sqlite/store.cpp
@@ -6,6 +6,27 @@
 #include <rocksdb/db.h>
 #include <rocksdb/utilities/write_batch_with_index.h>
 
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#endif
+
 // recFS is a sqlite3_vfs which records mutations of stateful SQLite DB files.
 struct recFS {
   sqlite3_vfs base;      // C-style subclass (is-a sqlite3_vfs).


### PR DESCRIPTION
We had been manually hacking this into our headers to build locally for over a year. I _believe_ this is their correct final resting place, or at least this change allows Gazette to build on my Mac without hacks.

This fix appears to come from https://github.com/zeromq/zmqpp/issues/164.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/392)
<!-- Reviewable:end -->
