### PR TITLE
make the maximum accepted gRPC message size configurable

### DIFF
--- a/cmd/gazette/main.go
+++ b/cmd/gazette/main.go
@@ -85,7 +85,7 @@ func (cmdServe) Execute(args []string) error {
 	}
 
 	// Bind our server listener, grabbing a random available port if Port is zero.
-	srv, err := server.New("", Config.Broker.Host, Config.Broker.Port, serverTLS, peerTLS)
+	srv, err := server.New("", Config.Broker.Host, Config.Broker.Port, serverTLS, peerTLS, Config.Broker.MaxGRPCRecvSize)
 	mbp.Must(err, "building Server instance")
 
 	// If a file:// root was provided, ensure it exists and apply it.

--- a/mainboilerplate/runconsumer/run_consumer.go
+++ b/mainboilerplate/runconsumer/run_consumer.go
@@ -149,7 +149,7 @@ func (sc Cmd) Execute(args []string) error {
 	}
 
 	// Bind our server listener, grabbing a random available port if Port is zero.
-	srv, err := server.New("", bc.Consumer.Host, bc.Consumer.Port, serverTLS, peerTLS)
+	srv, err := server.New("", bc.Consumer.Host, bc.Consumer.Port, serverTLS, peerTLS, bc.Consumer.MaxGRPCRecvSize)
 	mbp.Must(err, "building Server instance")
 
 	if bc.Broker.Cache.Size <= 0 {

--- a/mainboilerplate/service.go
+++ b/mainboilerplate/service.go
@@ -23,6 +23,7 @@ type ServiceConfig struct {
 	PeerCertFile      string `long:"peer-cert-file" env:"PEER_CERT_FILE" default:"" description:"Path to the client TLS certificate for peer-to-peer requests"`
 	PeerCertKeyFile   string `long:"peer-cert-key-file" env:"PEER_CERT_KEY_FILE" default:"" description:"Path to the client TLS private key for peer-to-peer requests"`
 	PeerCAFile        string `long:"peer-ca-file" env:"PEER_CA_FILE" default:"" description:"Path to the trusted CA for client verification of peer server certificates. When absent, the system CA pool is used instead."`
+	MaxGRPCRecvSize   uint32 `long:"max-grpc-recv-size" env:"MAX_GRPC_RECV_SIZE" default:"4194304" description:"Maximum size of gRPC messages accepted by this server, in bytes"`
 }
 
 // ProcessSpec of the ServiceConfig.


### PR DESCRIPTION
For Gazette and consumers. Previously, the default (4MB) was used and could not be changed. Now it's configurable by flag and environment variable for brokers and consumers:

  --broker.max-grpc-recv-size=  Maximum size of gRPC messages accepted by this server, in bytes (default: 4194304) [$BROKER_MAX_GRPC_RECV_SIZE]

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/398)
<!-- Reviewable:end -->
