### PR TITLE
broker/client: quiet more noisy logging

### DIFF
--- a/broker/client/list.go
+++ b/broker/client/list.go
@@ -97,6 +97,9 @@ func (pl *WatchedList) watch() {
 		} else {
 			stream = nil // Must restart.
 
+			if err == io.EOF {
+				attempt = 0 // Clean server-side close.
+			}
 			// Wait for back-off timer or context cancellation.
 			select {
 			case <-pl.ctx.Done():

--- a/broker/client/retry_reader.go
+++ b/broker/client/retry_reader.go
@@ -117,7 +117,7 @@ func (rr *RetryReader) Read(p []byte) (n int, err error) {
 			// any data before being closed server-side, so clear `attempts` to
 			// reduce log noise: it's common to next see ErrNotJournalBroker
 			// on broker topology changes or when authorizations are refreshed.
-			attempt = 0
+			attempt = -1
 			squelch = true
 		default:
 		}
@@ -222,6 +222,8 @@ func backoff(attempt int) time.Duration {
 	// involves a couple of Nagle-like read delays (~30ms) as Etcd watch
 	// updates are applied by participants.
 	switch attempt {
+	case -1:
+		return 0
 	case 0, 1:
 		return time.Millisecond * 50
 	case 2, 3:


### PR DESCRIPTION
Don't warn on a clean server-side close of a List RPC that doesn't ever return a response. This is expected for a resumed listing which doesn't change.

Use an attached Route of a previously completed Read, if available, and more importantly: clear the last Response of the previous stream. We could enter a condition where this was never cleared (for example, on NOT_JOURNAL_BROKER) if the _following_ request went to the correct broker, stayed open for a while with no data, and was then closed server-side. This can cause mis-leading and false-positive logged warnings.

Update RetryReader to account for attempt being incremented on the next loop iteration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/399)
<!-- Reviewable:end -->
