### PR TITLE
grpc-gateway: emit default (zero-value) fields

### DIFF
--- a/cmd/gazette/main.go
+++ b/cmd/gazette/main.go
@@ -120,7 +120,7 @@ func (cmdServe) Execute(args []string) error {
 	pb.RegisterJournalServer(srv.GRPCServer, pb.NewVerifiedJournalServer(service, verifier))
 
 	var mux *runtime.ServeMux = runtime.NewServeMux(
-		runtime.WithMarshalerOption(runtime.MIMEWildcard, new(gateway.JSONPb)),
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, &gateway.JSONPb{EmitDefaults: true}),
 		runtime.WithProtoErrorHandler(runtime.DefaultHTTPProtoErrorHandler),
 	)
 	pb.RegisterJournalHandler(tasks.Context(), mux, srv.GRPCLoopback)

--- a/mainboilerplate/runconsumer/run_consumer.go
+++ b/mainboilerplate/runconsumer/run_consumer.go
@@ -199,7 +199,7 @@ func (sc Cmd) Execute(args []string) error {
 	pc.RegisterShardServer(srv.GRPCServer, pc.NewVerifiedShardServer(service, service.Verifier))
 
 	var mux *runtime.ServeMux = runtime.NewServeMux(
-		runtime.WithMarshalerOption(runtime.MIMEWildcard, new(gateway.JSONPb)),
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, &gateway.JSONPb{EmitDefaults: true}),
 		runtime.WithProtoErrorHandler(runtime.DefaultHTTPProtoErrorHandler),
 	)
 	pc.RegisterShardHandler(tasks.Context(), mux, srv.GRPCLoopback)


### PR DESCRIPTION
Some existing clients are not as nimble at distinguishing the explicit empty vs implicit empty cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/401)
<!-- Reviewable:end -->
