### PR TITLE
server: update TLS config to not request a client cert at all

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -168,7 +168,7 @@ func New(
 
 func BuildTLSConfig(certPath, keyPath, trustedCAPath string) (*tls.Config, error) {
 	var tlsConfig = &tls.Config{
-		ClientAuth: tls.VerifyClientCertIfGiven,
+		ClientAuth: tls.NoClientCert,
 	}
 
 	// Load a presented certificate and key.


### PR DESCRIPTION
This was causing issues on Windows 11, which would give users pop-ups for them to select a client certificate to send to us.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/403)
<!-- Reviewable:end -->
