### PR TITLE
Add more information to se1quencer panic message

### DIFF
--- a/message/sequencer.go
+++ b/message/sequencer.go
@@ -408,7 +408,15 @@ func (w *Sequencer) Step() error {
 				// with one exception: messages with zero-valued Clocks are not
 				// expected to be consistently ordered on clock.
 				// In QueueUncommitted we synthetically assigned a clock value.
-				panic("ring clock <= emit.minClock")
+				panic(fmt.Sprintf("ring clock <= emit.minClock\n%+v", map[string]interface{}{
+					"uuid":          uuid,
+					"message":       w.Dequeued,
+					"dequeuedClock": w.dequeuedClock,
+					"offsets":       w.offsets,
+					"partials":      w.partials,
+					"pending":       w.pending,
+					"emit":          w.emit,
+				}))
 			}
 		} else if w.dequeuedClock > w.emit.maxClock {
 			continue // ACK'd clock tells us not to commit.


### PR DESCRIPTION
Adds a bunch more information to a panic message emitted by the sequencer, in an effort to troubleshoot the cause of the panic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/404)
<!-- Reviewable:end -->
