### PR TITLE
azure: Invalidate storage client if storage account name changes

### DIFF
--- a/broker/fragment/store_azure.go
+++ b/broker/fragment/store_azure.go
@@ -51,10 +51,10 @@ type udcAndExp struct {
 type azureBackend struct {
 	// This is a cache of configured Pipelines for each tenant. These do not expire
 	pipelines map[string]pipeline.Pipeline
-	// This is a cache of Azure storage clients for each tenant. These do not expire
+	// This is a cache of Azure storage clients for each tenant + storage account. These do not expire
 	clients map[string]*service.Client
 	mu      sync.Mutex
-	// This is a cache of URL-signing credentials for each tenant. These DO expire
+	// This is a cache of URL-signing credentials for each tenant + storage account. These DO expire
 	udcs map[string]udcAndExp
 }
 
@@ -274,7 +274,7 @@ func parseAzureEndpoint(endpoint *url.URL) (cfg azureStoreConfig, err error) {
 	return cfg, nil
 }
 
-func (a *azureBackend) getAzureServiceClient(endpoint *url.URL) (client *service.Client, err error) {
+func (a *azureBackend) getAzureStorageClient(endpoint *url.URL) (client *service.Client, err error) {
 	var cfg azureStoreConfig
 
 	if cfg, err = parseAzureEndpoint(endpoint); err != nil {
@@ -286,15 +286,21 @@ func (a *azureBackend) getAzureServiceClient(endpoint *url.URL) (client *service
 		var accountKey = os.Getenv("AZURE_ACCOUNT_KEY")
 
 		a.mu.Lock()
-		client, ok := a.clients[accountName]
+		client, ok := a.clients[accountName+cfg.storageAccountName]
 		a.mu.Unlock()
 
 		if ok {
 			log.WithFields(log.Fields{
 				"storageAccountName": accountName,
-			}).Info("Re-using cached azure:// service client")
+				"containerName":      cfg.containerName,
+			}).Info("Re-using cached azure:// storage account client")
 			return client, nil
 		}
+
+		log.WithFields(log.Fields{
+			"storageAccountName": accountName,
+			"containerName":      cfg.containerName,
+		}).Info("Building new azure:// storage account client")
 
 		sharedKeyCred, err := service.NewSharedKeyCredential(accountName, accountKey)
 		if err != nil {
@@ -306,7 +312,7 @@ func (a *azureBackend) getAzureServiceClient(endpoint *url.URL) (client *service
 		}
 
 		a.mu.Lock()
-		a.clients[accountName] = serviceClient
+		a.clients[accountName+cfg.storageAccountName] = serviceClient
 		a.mu.Unlock()
 		return serviceClient, nil
 	} else if endpoint.Scheme == "azure-ad" {
@@ -316,15 +322,23 @@ func (a *azureBackend) getAzureServiceClient(endpoint *url.URL) (client *service
 		var clientSecret = os.Getenv("AZURE_CLIENT_SECRET")
 
 		a.mu.Lock()
-		client, ok := a.clients[cfg.accountTenantID]
+		client, ok := a.clients[cfg.accountTenantID+cfg.storageAccountName]
 		a.mu.Unlock()
 
 		if ok {
 			log.WithFields(log.Fields{
-				"accountTenantId": cfg.accountTenantID,
-			}).Info("Re-using cached azure-ad:// service client")
+				"accountTenantId":    cfg.accountTenantID,
+				"storageAccountName": cfg.storageAccountName,
+				"containerName":      cfg.containerName,
+			}).Info("Re-using cached azure-ad:// storage account client")
 			return client, nil
 		}
+
+		log.WithFields(log.Fields{
+			"accountTenantId":    cfg.accountTenantID,
+			"storageAccountName": cfg.storageAccountName,
+			"containerName":      cfg.containerName,
+		}).Info("Building new azure-ad:// storage account client")
 
 		identityCreds, err := azidentity.NewClientSecretCredential(
 			cfg.accountTenantID,
@@ -345,7 +359,7 @@ func (a *azureBackend) getAzureServiceClient(endpoint *url.URL) (client *service
 		}
 
 		a.mu.Lock()
-		a.clients[cfg.accountTenantID] = serviceClient
+		a.clients[cfg.accountTenantID+cfg.storageAccountName] = serviceClient
 		a.mu.Unlock()
 
 		return serviceClient, nil
@@ -409,10 +423,8 @@ func (a *azureBackend) getAzurePipeline(ep *url.URL) (cfg azureStoreConfig, clie
 	a.mu.Unlock()
 
 	log.WithFields(log.Fields{
-		"tenant":               cfg.accountTenantID,
-		"storageAccountName":   cfg.storageAccountName,
-		"storageContainerName": cfg.containerName,
-		"pathPrefix":           cfg.prefix,
+		"tenant":     cfg.accountTenantID,
+		"pathPrefix": cfg.prefix,
 	}).Info("constructed new Azure Storage pipeline client")
 
 	return cfg, client, nil
@@ -434,7 +446,7 @@ func (a *azureBackend) getUserDelegationCredential(endpoint *url.URL) (*service.
 		return nil, err
 	}
 	a.mu.Lock()
-	var udc, hasCachedUdc = a.udcs[cfg.accountTenantID]
+	var udc, hasCachedUdc = a.udcs[cfg.accountTenantID+cfg.storageAccountName]
 	a.mu.Unlock()
 
 	// https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-user-delegation-sas-create-cli#use-azure-ad-credentials-to-secure-a-sas
@@ -455,21 +467,22 @@ func (a *azureBackend) getUserDelegationCredential(endpoint *url.URL) (*service.
 			Expiry: to.Ptr(expTime.UTC().Format(sas.TimeFormat)),
 		}
 
-		var serviceClient, err = a.getAzureServiceClient(endpoint)
+		var storageClient, err = a.getAzureStorageClient(endpoint)
 		if err != nil {
 			return nil, err
 		}
 
-		cred, err := serviceClient.GetUserDelegationCredential(context.Background(), info, nil)
+		cred, err := storageClient.GetUserDelegationCredential(context.Background(), info, nil)
 		if err != nil {
 			return nil, err
 		}
 
 		log.WithFields(log.Fields{
-			"newExpiration":   expTime,
-			"newStart":        startTime.String(),
-			"service.KeyInfo": info,
-			"tenant":          cfg.accountTenantID,
+			"newExpiration":      expTime,
+			"newStart":           startTime.String(),
+			"service.KeyInfo":    info,
+			"tenant":             cfg.accountTenantID,
+			"storageAccountName": cfg.storageAccountName,
 		}).Info("Refreshing Azure Storage UDC")
 
 		udc = udcAndExp{
@@ -477,7 +490,7 @@ func (a *azureBackend) getUserDelegationCredential(endpoint *url.URL) (*service.
 			exp: &expTime,
 		}
 		a.mu.Lock()
-		a.udcs[cfg.accountTenantID] = udc
+		a.udcs[cfg.accountTenantID+cfg.storageAccountName] = udc
 		a.mu.Unlock()
 	}
 


### PR DESCRIPTION
We ran into this when a customer changed their storage account name. Fragment listings for their journal were returning errors complaining about resolving the hostname of the _previous_ storage account, even through the fragment spec correctly specified new storage account name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/409)
<!-- Reviewable:end -->
