### PR TITLE
broker: tear down a stale append pipeline before proxying

### DIFF
--- a/broker/append_fsm.go
+++ b/broker/append_fsm.go
@@ -154,7 +154,11 @@ func (b *appendFSM) onResolve() {
 		b.state = stateError
 	} else if b.resolved.ProcessId != b.resolved.localID {
 		// If we hold the pipeline from a previous resolution but are no longer
-		// primary, we must release it.
+		// primary, we must tear it down to release replica spools.
+		if b.pln != nil {
+			go b.pln.shutdown(false)
+			b.pln = nil
+		}
 		b.returnPipeline()
 		b.state = stateAwaitDesiredReplicas // We must proxy.
 	} else if b.plnReturnCh != nil {


### PR DESCRIPTION
This can happen if we were primary, but have been re-assigned as a replica without an observed cancellation of our assignment in between.

We must tear down the stale pipeline to release replica spools before we return it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/414)
<!-- Reviewable:end -->
