### PR TITLE
broker: tear down and restart a demoted replica

### DIFF
--- a/allocator/allocator_test.go
+++ b/allocator/allocator_test.go
@@ -159,9 +159,7 @@ func (s *AllocatorSuite) TestTxnBatching(c *gc.C) {
 	))
 
 	// Final commit. Expect it flushes the last checkpoint.
-	var r, err = txn.Commit()
-	c.Check(r, gc.Equals, txnResp)
-	c.Check(err, gc.IsNil)
+	c.Check(txn.Flush(), gc.IsNil)
 
 	c.Check(txnOp, gc.DeepEquals, clientv3.OpTxn(
 		[]clientv3.Cmp{fixedCmp, testCmp},
@@ -172,17 +170,13 @@ func (s *AllocatorSuite) TestTxnBatching(c *gc.C) {
 	// Empty Checkpoint, then Commit. Expect it's treated as a no-op.
 	c.Check(txn.Checkpoint(), gc.IsNil)
 
-	r, err = txn.Commit()
-	c.Check(r, gc.IsNil)
-	c.Check(err, gc.IsNil)
+	c.Check(txn.Flush(), gc.IsNil)
 
 	// Non-empty commit that fails checks. Expect it's mapped to an error.
 	c.Check(txn.Then(testOp).Checkpoint(), gc.IsNil)
 	txnResp.Succeeded = false
 
-	r, err = txn.Commit()
-	c.Check(r, gc.Equals, txnResp)
-	c.Check(err, gc.ErrorMatches, "transaction checks did not succeed")
+	c.Check(txn.Flush(), gc.ErrorMatches, "transaction checks did not succeed")
 }
 
 var _ = gc.Suite(&AllocatorSuite{})

--- a/allocator/item_state_test.go
+++ b/allocator/item_state_test.go
@@ -424,9 +424,10 @@ type mockTxnBuilder struct {
 	ops  []clientv3.Op
 }
 
-func (b *mockTxnBuilder) If(c ...clientv3.Cmp) checkpointTxn     { b.cmps = append(b.cmps, c...); return b }
-func (b *mockTxnBuilder) Then(o ...clientv3.Op) checkpointTxn    { b.ops = append(b.ops, o...); return b }
-func (b *mockTxnBuilder) Checkpoint() error                      { return nil }
-func (b *mockTxnBuilder) Commit() (*clientv3.TxnResponse, error) { panic("not supported") }
+func (b *mockTxnBuilder) If(c ...clientv3.Cmp) checkpointTxn  { b.cmps = append(b.cmps, c...); return b }
+func (b *mockTxnBuilder) Then(o ...clientv3.Op) checkpointTxn { b.ops = append(b.ops, o...); return b }
+func (b *mockTxnBuilder) Checkpoint() error                   { return nil }
+func (b *mockTxnBuilder) Flush() error                        { panic("not supported") }
+func (b *mockTxnBuilder) Revision() int64                     { panic("not supported") }
 
 var _ = gc.Suite(&ItemStateSuite{})

--- a/allocator/scenarios_test.go
+++ b/allocator/scenarios_test.go
@@ -890,8 +890,7 @@ func insert(ctx context.Context, client *clientv3.Client, keyValues ...string) e
 			return err
 		}
 	}
-	var _, err = txn.Commit()
-	return err
+	return txn.Flush()
 }
 
 // update updates keys with values, requiring that the key already exist.
@@ -906,8 +905,7 @@ func update(ctx context.Context, client *clientv3.Client, keyValues ...string) e
 			return err
 		}
 	}
-	var _, err = txn.Commit()
-	return err
+	return txn.Flush()
 }
 
 // markAllConsistent which updates all Assignments to have a value of "consistent".
@@ -928,9 +926,9 @@ func markAllConsistent(ctx context.Context, client *clientv3.Client, ks *keyspac
 		}
 	}
 
-	if _, err := txn.Commit(); err != nil {
+	if err := txn.Flush(); err != nil {
 		return err
-	} else if txn.noop {
+	} else if txn.Revision() == 0 {
 		return io.ErrNoProgress
 	} else {
 		return nil

--- a/broker/append_fsm.go
+++ b/broker/append_fsm.go
@@ -154,11 +154,7 @@ func (b *appendFSM) onResolve() {
 		b.state = stateError
 	} else if b.resolved.ProcessId != b.resolved.localID {
 		// If we hold the pipeline from a previous resolution but are no longer
-		// primary, we must tear it down to release replica spools.
-		if b.pln != nil {
-			go b.pln.shutdown(false)
-			b.pln = nil
-		}
+		// primary, we must release it.
 		b.returnPipeline()
 		b.state = stateAwaitDesiredReplicas // We must proxy.
 	} else if b.plnReturnCh != nil {


### PR DESCRIPTION
Second attempt at making sure pipelines are released in this scenario.

Under this approach, we cancel the whole replica and build a new one, relying on the existing replica cancellation and shutdown behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/415)
<!-- Reviewable:end -->
