### PR TITLE
scale allocator member ItemLimit to the relative share of ItemSlots, and refine suspension eligibility

### DIFF
--- a/broker/fragment/index_test.go
+++ b/broker/fragment/index_test.go
@@ -288,7 +288,7 @@ func (s *IndexSuite) TestWalkStoresAndURLSigning(c *gc.C) {
 	<-ind.FirstRefreshCh()
 
 	c.Check(ind.set, gc.HasLen, 3)
-	var bo, eo, _ = ind.OffsetRange()
+	var bo, eo, _ = ind.Summary()
 	c.Check(bo, gc.Equals, int64(0x0))
 	c.Check(eo, gc.Equals, int64(0x255))
 
@@ -306,7 +306,7 @@ func (s *IndexSuite) TestWalkStoresAndURLSigning(c *gc.C) {
 	ind.ReplaceRemote(set)
 
 	c.Check(ind.set, gc.HasLen, 4) // Combined Fragments are reflected.
-	bo, eo, _ = ind.OffsetRange()
+	bo, eo, _ = ind.Summary()
 	c.Check(bo, gc.Equals, int64(0x0))
 	c.Check(eo, gc.Equals, int64(0x555))
 

--- a/broker/replicate_api_test.go
+++ b/broker/replicate_api_test.go
@@ -40,7 +40,7 @@ func TestReplicateStreamAndCommit(t *testing.T) {
 	require.NoError(t, stream.Send(&pb.ReplicateRequest{Content: []byte("bazbing"), ContentDelta: 6}))
 
 	// Precondition: content not observable in the Fragment index.
-	var _, eo, _ = broker.replica("a/journal").index.OffsetRange()
+	var _, eo, _ = broker.replica("a/journal").index.Summary()
 	require.Equal(t, int64(0), eo)
 
 	// Commit.
@@ -58,7 +58,7 @@ func TestReplicateStreamAndCommit(t *testing.T) {
 	expectReplResponse(t, stream, &pb.ReplicateResponse{Status: pb.Status_OK})
 
 	// Post-condition: content is now observable.
-	_, eo, _ = broker.replica("a/journal").index.OffsetRange()
+	_, eo, _ = broker.replica("a/journal").index.Summary()
 	require.Equal(t, int64(13), eo)
 
 	// Send EOF and expect its returned.


### PR DESCRIPTION
ItemSlots may be unevenly distributed amoung assignment sub-problems.

We need to account for this, by scaling member ItemLimits by the relative portion of assignment slots that must be allocated within each sub-problem, rather than just the relative number of items.

Also, tune journal suspension to apply the journal's configured flush interval when evaluating whether the index is "dirty".

See individual commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/416)
<!-- Reviewable:end -->
