### PR TITLE
consumer: resolution should allow omitted ProcessId

### DIFF
--- a/broker/resolver.go
+++ b/broker/resolver.go
@@ -103,15 +103,15 @@ func (r *resolver) resolve(ctx context.Context, claims pb.Claims, journal pb.Jou
 	}
 
 	if hdr := opts.proxyHeader; hdr != nil {
-		// Sanity check the proxy broker is using our same Etcd cluster.
+		// Verify the requestor is using our same Etcd cluster.
 		if hdr.Etcd.ClusterId != ks.Header.ClusterId {
-			err = fmt.Errorf("proxied request Etcd ClusterId doesn't match our own (%d vs %d)",
+			err = fmt.Errorf("request Etcd ClusterId doesn't match our own (%d vs %d)",
 				hdr.Etcd.ClusterId, ks.Header.ClusterId)
 			return
 		}
-		// Sanity-check that the proxy broker reached the intended recipient.
+		// Verify the requestor reached the intended member.
 		if hdr.ProcessId != (pb.ProcessSpec_ID{}) && hdr.ProcessId != res.localID {
-			err = fmt.Errorf("proxied request ProcessId doesn't match our own (%s vs %s)",
+			err = fmt.Errorf("request ProcessId doesn't match our own (%s vs %s)",
 				&hdr.ProcessId, &res.localID)
 			return
 		}

--- a/broker/resolver_test.go
+++ b/broker/resolver_test.go
@@ -282,13 +282,13 @@ func TestResolveProxyHeaderErrorCases(t *testing.T) {
 
 	// Case: proxy header references a broker other than this one.
 	var _, err = broker.svc.resolver.resolve(ctx, allClaims, "a/journal", resolveOpts{proxyHeader: &proxy})
-	require.Regexp(t, `proxied request ProcessId doesn't match our own \(zone.*`, err)
+	require.Regexp(t, `request ProcessId doesn't match our own \(zone.*`, err)
 	proxy.ProcessId = broker.id
 
 	// Case: proxy header references a ClusterId other than our own.
 	proxy.Etcd.ClusterId = 8675309
 	_, err = broker.svc.resolver.resolve(ctx, allClaims, "a/journal", resolveOpts{proxyHeader: &proxy})
-	require.Regexp(t, `proxied request Etcd ClusterId doesn't match our own \(\d+.*`, err)
+	require.Regexp(t, `request Etcd ClusterId doesn't match our own \(\d+.*`, err)
 
 	broker.cleanup()
 }

--- a/consumer/resolver.go
+++ b/consumer/resolver.go
@@ -122,15 +122,15 @@ func (r *Resolver) Resolve(args ResolveArgs) (res Resolution, err error) {
 	}
 
 	if hdr := args.ProxyHeader; hdr != nil {
-		// Sanity check the proxy broker is using our same Etcd cluster.
+		// Verify the requestor is using our same Etcd cluster.
 		if hdr.Etcd.ClusterId != ks.Header.ClusterId {
-			err = fmt.Errorf("proxied request Etcd ClusterId doesn't match our own (%d vs %d)",
+			err = fmt.Errorf("request Etcd ClusterId doesn't match our own (%d vs %d)",
 				hdr.Etcd.ClusterId, ks.Header.ClusterId)
 			return
 		}
-		// Sanity-check that the proxy broker reached the intended recipient.
-		if hdr.ProcessId != localID {
-			err = fmt.Errorf("proxied request ProcessId doesn't match our own (%s vs %s)",
+		// Verify the requestor reached the intended member.
+		if hdr.ProcessId != (pb.ProcessSpec_ID{}) && hdr.ProcessId != localID {
+			err = fmt.Errorf("request ProcessId doesn't match our own (%s vs %s)",
 				&hdr.ProcessId, &localID)
 			return
 		}

--- a/consumer/resolver_test.go
+++ b/consumer/resolver_test.go
@@ -183,7 +183,7 @@ func TestResolverErrorCases(t *testing.T) {
 			},
 		},
 	})
-	require.Regexp(t, `proxied request Etcd ClusterId doesn't match our own \(\d+ vs \d+\)`, err)
+	require.Regexp(t, `request Etcd ClusterId doesn't match our own \(\d+ vs \d+\)`, err)
 
 	// Case: ProxyHeader has wrong ProcessID.
 	_, err = tf.resolver.Resolve(ResolveArgs{
@@ -196,7 +196,7 @@ func TestResolverErrorCases(t *testing.T) {
 			},
 		},
 	})
-	require.Regexp(t, `proxied request ProcessId doesn't match our own \(zone.*\)`, err)
+	require.Regexp(t, `request ProcessId doesn't match our own \(zone.*\)`, err)
 
 	// Case: Context cancelled while waiting for a future revision.
 	var ctx, cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
Even if the header is present. This matches broker behavior, and allows clients to send along Etcd revisions to await (received from a peer), which can speed overall adjustments to topology changes within the cluster.

Also tweak errors to not assume that requests with headers imply proxied requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/417)
<!-- Reviewable:end -->
