### PR TITLE
message: nil out dequeued Envelope.Message after consumption

### DIFF
--- a/message/sequencer.go
+++ b/message/sequencer.go
@@ -354,6 +354,7 @@ func (w *Sequencer) Step() error {
 	if w.Dequeued != nil {
 		// Tighten clock to the processed Envelope.
 		w.emit.minClock = w.dequeuedClock
+		w.Dequeued.Message = nil // Release memory.
 	}
 
 	for w.emit.ringStart != -1 {


### PR DESCRIPTION
Otherwise, the ring will indefinetely retain messages which have already been processed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/422)
<!-- Reviewable:end -->
