### PR TITLE
add client support for pre-shared authorization tokens

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -73,6 +73,22 @@ func (k *KeyedAuth) Verify(ctx context.Context, require pb.Capability) (context.
 	}
 }
 
+// NewBearerAuth returns a BearerAuth that implements Authorizer
+// using a pre-shared authorization token.
+func NewBearerAuth(token string) *BearerAuth {
+	return &BearerAuth{token: token}
+
+}
+
+// BearerAuth implements the pb.Authorizer interface.
+type BearerAuth struct {
+	token string
+}
+
+func (b *BearerAuth) Authorize(ctx context.Context, _claims pb.Claims, _exp time.Duration) (context.Context, error) {
+	return metadata.AppendToOutgoingContext(ctx, "authorization", fmt.Sprintf("Bearer %s", b.token)), nil
+}
+
 // NewNoopAuth returns an Authorizer and Verifier which does nothing.
 func NewNoopAuth() interface {
 	pb.Authorizer

--- a/mainboilerplate/client.go
+++ b/mainboilerplate/client.go
@@ -23,6 +23,7 @@ type AddressConfig struct {
 	CertKeyFile   string      `long:"cert-key-file" env:"CERT_KEY_FILE" default:"" description:"Path to the client TLS private key"`
 	TrustedCAFile string      `long:"trusted-ca-file" env:"TRUSTED_CA_FILE" default:"" description:"Path to the trusted CA for client verification of server certificates"`
 	AuthKeys      string      `long:"auth-keys" env:"AUTH_KEYS" description:"Whitespace or comma separated, base64-encoded keys. The first key is used to sign Authorization tokens." json:"-"`
+	AuthToken     string      `long:"auth-token" env:"AUTH_TOKEN" description:"Bearer token to use for authentication." json:"-"`
 }
 
 // MustDial dials the server address using a protocol.Dispatcher balancer, and panics on error.
@@ -65,6 +66,8 @@ func (c *AddressConfig) MustJournalClient(ctx context.Context) pb.JournalClient 
 	if c.AuthKeys != "" {
 		authorizer, err = auth.NewKeyedAuth(c.AuthKeys)
 		Must(err, "parsing authorization keys")
+	} else if c.AuthToken != "" {
+		authorizer = auth.NewBearerAuth(c.AuthToken)
 	} else {
 		authorizer = auth.NewNoopAuth()
 	}
@@ -87,6 +90,8 @@ func (c *AddressConfig) MustShardClient(ctx context.Context) pc.ShardClient {
 	if c.AuthKeys != "" {
 		authorizer, err = auth.NewKeyedAuth(c.AuthKeys)
 		Must(err, "parsing authorization keys")
+	} else if c.AuthToken != "" {
+		authorizer = auth.NewBearerAuth(c.AuthToken)
 	} else {
 		authorizer = auth.NewNoopAuth()
 	}


### PR DESCRIPTION
BROKER_AUTH_TOKEN and CONSUMER_AUTH_TOKEN, when present, are used as pre-shared bearer authorization tokens submitted with client requests.

This enables `gazctl` and other client applications to make use of pre-shared authorization tokens which are negotiated as part of a larger authorization context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/432)
<!-- Reviewable:end -->
