### PR TITLE
Update Apply APIs to authorize Upserts against full label sets

### DIFF
--- a/broker/list_apply_api.go
+++ b/broker/list_apply_api.go
@@ -219,30 +219,26 @@ func (svc *Service) Apply(ctx context.Context, claims pb.Claims, req *pb.ApplyRe
 		return nil, err
 	}
 
-	// The Apply API is authorized exclusively through the "name" label.
-	var authorizeJournal = func(claims *pb.Claims, journal pb.Journal) error {
-		if !claims.Selector.Matches(pb.MustLabelSet("name", journal.String())) {
-			return status.Error(codes.Unauthenticated, fmt.Sprintf("not authorized to %s", journal))
-		}
-		return nil
-	}
-
 	var cmp []clientv3.Cmp
 	var ops []clientv3.Op
 	var s = svc.resolver.state
+	var scratch pb.LabelSet
 
 	for _, change := range req.Changes {
 		var key string
 
 		if change.Upsert != nil {
-			if err = authorizeJournal(&claims, change.Upsert.Name); err != nil {
-				return nil, err
+			// For Upserts, authorize against the journal's labels plus meta-labels
+			scratch = change.Upsert.LabelSetExt(scratch)
+			if !claims.Selector.Matches(scratch) {
+				return nil, status.Error(codes.Unauthenticated, fmt.Sprintf("not authorized to %s", change.Upsert.Name))
 			}
 			key = allocator.ItemKey(s.KS, change.Upsert.Name.String())
 			ops = append(ops, clientv3.OpPut(key, change.Upsert.MarshalString()))
 		} else {
-			if err = authorizeJournal(&claims, change.Delete); err != nil {
-				return nil, err
+			// For Deletes, use name-only authorization
+			if !claims.Selector.Matches(pb.MustLabelSet("name", change.Delete.String())) {
+				return nil, status.Error(codes.Unauthenticated, fmt.Sprintf("not authorized to %s", change.Delete))
 			}
 			key = allocator.ItemKey(s.KS, change.Delete.String())
 			ops = append(ops, clientv3.OpDelete(key))

--- a/consumer/shard_api.go
+++ b/consumer/shard_api.go
@@ -108,22 +108,18 @@ func ShardApply(ctx context.Context, claims pb.Claims, srv *Service, req *pc.App
 		return nil, err
 	}
 
-	// The Apply API is authorized exclusively through the "id" label.
-	var authorizeShard = func(claims *pb.Claims, shard pc.ShardID) error {
-		if !claims.Selector.Matches(pb.MustLabelSet("id", shard.String())) {
-			return status.Error(codes.Unauthenticated, fmt.Sprintf("not authorized to %s", shard))
-		}
-		return nil
-	}
 	var cmp []clientv3.Cmp
 	var ops []clientv3.Op
+	var scratch pb.LabelSet
 
 	for _, change := range req.Changes {
 		var key string
 
 		if change.Upsert != nil {
-			if err := authorizeShard(&claims, change.Upsert.Id); err != nil {
-				return nil, err
+			// For Upserts, authorize against the shard's labels plus meta-labels
+			scratch = change.Upsert.LabelSetExt(scratch)
+			if !claims.Selector.Matches(scratch) {
+				return nil, status.Error(codes.Unauthenticated, fmt.Sprintf("not authorized to %s", change.Upsert.Id))
 			}
 			key = allocator.ItemKey(s.KS, change.Upsert.Id.String())
 			ops = append(ops, clientv3.OpPut(key, change.Upsert.MarshalString()))
@@ -136,8 +132,9 @@ func ShardApply(ctx context.Context, claims pb.Claims, srv *Service, req *pc.App
 				ops = append(ops, clientv3.OpPut(change.Upsert.HintPrimaryKey(), string(val)))
 			}
 		} else {
-			if err := authorizeShard(&claims, change.Delete); err != nil {
-				return nil, err
+			// For Deletes, use id-only authorization
+			if !claims.Selector.Matches(pb.MustLabelSet("id", change.Delete.String())) {
+				return nil, status.Error(codes.Unauthenticated, fmt.Sprintf("not authorized to %s", change.Delete))
 			}
 			key = allocator.ItemKey(s.KS, change.Delete.String())
 			ops = append(ops, clientv3.OpDelete(key))


### PR DESCRIPTION
This change updates both the broker and consumer Apply APIs to handle label selectors differently for Upserts and Deletes:

For Upserts:
- Authorization now checks against the full label set (including meta-labels)
- Uses LabelSetExt() to get all labels including "name" (broker) or "id" (consumer)
- Ensures consistency with how List operations authorize

For Deletes:
- Maintains backward compatibility with name-only (broker) or id-only (consumer) authorization
- No change in behavior for delete operations

This change ensures that users with label-based claims can only upsert journals/shards if their claims match all the labels on the resource, not just the name/id. This provides more granular access control.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/434)
<!-- Reviewable:end -->
