### PR TITLE
fragment: slightly relax offset skip behavior

### DIFF
--- a/broker/fragment/index.go
+++ b/broker/fragment/index.go
@@ -57,9 +57,9 @@ func (fi *Index) Query(ctx context.Context, req *pb.ReadRequest) (*pb.ReadRespon
 		// If the requested offset isn't covered by the index, but we do have
 		// a persisted fragment with a *greater* offset...
 		if !found && ind != len(fi.set) && fi.set[ind].ModTime != 0 &&
-			// AND the client is reading from the very beginning of the journal,
+			// AND the client is reading from the very beginning of the available journal,
 			// OR the next available fragment was persisted quite a while ago.
-			(req.Offset == 0 || (fi.set[ind].ModTime < timeNow().Add(-offsetJumpAgeThreshold).Unix())) {
+			(ind == 0 || (fi.set[ind].ModTime < timeNow().Add(-offsetJumpAgeThreshold).Unix())) {
 
 			// Then skip the read forward to the first or next available offset.
 			// This case allows us to recover from "holes" or deletions in the


### PR DESCRIPTION
Currently we will immediately skip forward a read if it begins at offset zero.

However, we also see cases where a long-disabled task will come back online, observe an ACK, and then attempt a replay-read from an offset fixed in its recovery log. These reads block for the full offset jump threshold.

Resolve this by skipping forward any read having an offset behind the minimum available offset of journal content.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/437)
<!-- Reviewable:end -->
