### PR TITLE
feat: handle additional non-retryable errors in append service

### DIFF
--- a/broker/client/append_service.go
+++ b/broker/client/append_service.go
@@ -395,9 +395,11 @@ var serveAppends = func(s *AppendService, aa *AsyncAppend, err error) {
 
 					if err2 == context.Canceled || err2 == context.DeadlineExceeded ||
 						errors.Is(err2, ErrFragmentStoreUnhealthy) ||
+						errors.Is(err2, ErrIndexHasGreaterOffset) ||
+						errors.Is(err2, ErrJournalNotFound) ||
+						errors.Is(err2, ErrNotAllowed) ||
 						errors.Is(err2, ErrRegisterMismatch) ||
-						err2 == ErrIndexHasGreaterOffset ||
-						err2 == ErrNotAllowed {
+						errors.Is(err2, ErrWrongAppendOffset) {
 						err = err2
 						return nil // Break retry loop.
 					} else if err2 != nil {

--- a/broker/client/append_service_test.go
+++ b/broker/client/append_service_test.go
@@ -277,6 +277,14 @@ func (s *AppendServiceSuite) TestAppendNonRetryableErrors(c *gc.C) {
 			status: pb.Status_NOT_ALLOWED,
 			errMsg: "NOT_ALLOWED",
 		},
+		{
+			status: pb.Status_JOURNAL_NOT_FOUND,
+			errMsg: "JOURNAL_NOT_FOUND",
+		},
+		{
+			status: pb.Status_WRONG_APPEND_OFFSET,
+			errMsg: "WRONG_APPEND_OFFSET",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Added ErrJournalNotFound and ErrWrongAppendOffset to the list of non-retryable errors that break out of the append retry loop.

Updated tests to cover the new error types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/439)
<!-- Reviewable:end -->
