### PR TITLE
stores: increase OK health-check interval and jitter

### DIFF
--- a/broker/stores/health_check.go
+++ b/broker/stores/health_check.go
@@ -35,7 +35,7 @@ func checkLoop(stores map[pb.FragmentStore]*ActiveStore, fs pb.FragmentStore, at
 	var checkInterval time.Duration
 
 	if err == nil {
-		checkInterval = 5 * time.Minute
+		checkInterval = 30 * time.Minute
 
 		log.WithFields(log.Fields{
 			"store":    fs,
@@ -66,8 +66,8 @@ func checkLoop(stores map[pb.FragmentStore]*ActiveStore, fs pb.FragmentStore, at
 		attempt += 1
 	}
 
-	// Schedule next check with +/- 5% jitter to prevent thundering herd
-	checkInterval += time.Duration((rand.Float64() - 0.5) * 0.1 * float64(checkInterval))
+	// Schedule next check with +/- 20% jitter to prevent thundering herd
+	checkInterval += time.Duration((rand.Float64() - 0.5) * 0.4 * float64(checkInterval))
 
 	storesMu.RLock()
 	if a, ok := stores[fs]; ok && a == active {

--- a/broker/stores/stores_test.go
+++ b/broker/stores/stores_test.go
@@ -358,19 +358,15 @@ func TestHealthStatusAfterSweep(t *testing.T) {
 		},
 	})
 
-	// Create a store
-	store := Get(pb.FragmentStore("s3://test/"))
+	var store = Get(pb.FragmentStore("s3://test/"))
 	require.NoError(t, store.initErr)
 
 	// Wait for initial health check to complete
-	done, _ := store.HealthStatus()
-	<-done
-
-	// Update health to success
-	store.UpdateHealth(nil)
-
-	// Verify health is good
-	var _, err = store.HealthStatus()
+	done, err := store.HealthStatus()
+	if err == ErrFirstHealthCheck {
+		<-done
+	}
+	_, err = store.HealthStatus()
 	require.NoError(t, err)
 
 	// First sweep clears the mark (store was marked on creation)


### PR DESCRIPTION
GCS, and possibly other stores, have rate limits on how quickly an object may be updated that we sometimes see. It succeeds on retry, but the 5 minute interval when all is okay was motivated by testing, and is perhaps too aggressive in production.

Also increase jitter to quickly spread out the health checks of blocks of brokers starting at correlated times.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/440)
<!-- Reviewable:end -->
