### PR TITLE
server: offer "http/1.1" and "h2" via ALPN

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -108,6 +108,15 @@ func New(
 			grpc.MaxRecvMsgSize(int(maxGRPCRecvSize)),
 		),
 	}
+
+	// gRPC v1.67+ requires that we advertise "h2" via ALPN.
+	// However we only offer HTTP/2 for gRPC connections,
+	// so pick it only if "http/1.1" isn't offered
+	// (which is true only of gRPC clients).
+	if serverTLS != nil {
+		serverTLS.NextProtos = []string{"http/1.1", "h2"}
+	}
+
 	if wrapListener != nil {
 		if listener, err = wrapListener(listener, serverTLS); err != nil {
 			return nil, fmt.Errorf("failed to wrap listener: %w", err)


### PR DESCRIPTION
As per the gRPC spec, recent clients require that we offer "h2".

So, offer both "http/1.1" and "h2", preferring "http/1.1". Regular HTTP clients will negotiate http/1.1 (h2 is not supported), and gRPC clients (which don't offer http/1.1) will negotiate h2.