### PR TITLE
Fixed typo: Kakfa -> Kafka

### DIFF
--- a/docs/architecture-design-goals-and-nongoals.rst
+++ b/docs/architecture-design-goals-and-nongoals.rst
@@ -7,7 +7,7 @@ influences.
 
 **Journals provide global record ordering and publish/subscribe**
 
-Much like Kakfa, LogDevice, Apache BookKeeper, and others. These properties are
+Much like Kafka, LogDevice, Apache BookKeeper, and others. These properties are
 the basic building blocks for assembling platforms composed of streaming,
 decoupled, and event-sourced services.
 


### PR DESCRIPTION
This PR replaces the work "Kakfa" - which I assume is a typo - on the page https://github.com/gazette/core/blob/master/docs/architecture-design-goals-and-nongoals.rst with "Kafka".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gazette/core/447)
<!-- Reviewable:end -->
