### PR TITLE
broker: size read chunks to fit gRPC's 32KB buffer pool tier

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -22,6 +22,7 @@ jobs:
             docker login --username ${{ github.actor }} --password-stdin ghcr.io
 
       - uses: actions/setup-go@v4
+      - run: sudo apt update
       - run: sudo apt install -y protobuf-compiler librocksdb-dev libsqlite3-dev etcd-server
       - run: echo "VERSION=$(git describe --dirty --tags)" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Reduce chunkSize from 128KB to (32KB - 32) so that marshaled ReadResponse messages stay under 32KB. gRPC's internal buffer pool has tiers at 256, 4KB, 16KB, 32KB, and 1MB — exceeding 32KB rounds up to 1MB allocations which can be pinned for extended periods when readers are slow, causing excessive memory usage.