### PR TITLE
Revert "allocator: zero limit in SetExiting for backward compatibility"

### DIFF
--- a/allocator/allocator_key_space_test.go
+++ b/allocator/allocator_key_space_test.go
@@ -361,8 +361,7 @@ type testMember struct {
 
 func (m testMember) ItemLimit() int   { return m.R }
 func (m testMember) Validate() error  { return nil }
-// TODO(whb): Zero'ing R is for backward compatibility; remove once deployment is complete.
-func (m *testMember) SetExiting()     { m.E = true; m.R = 0 }
+func (m *testMember) SetExiting()     { m.E = true }
 func (m testMember) IsExiting() bool  { return m.E }
 
 func (m *testMember) MarshalString() string {

--- a/allocator/announce_test.go
+++ b/allocator/announce_test.go
@@ -127,8 +127,7 @@ func (s *AnnounceSuite) TestBasicSessionStart(c *gc.C) {
 	close(sigCh)
 
 	c.Check(args.Tasks.Wait(), gc.IsNil) // All tasks have exited.
-	c.Check(spec.E, gc.Equals, true) // Member was marked as exiting.
-	c.Check(spec.R, gc.Equals, 0)   // TODO(whb): Remove once backward compat is removed.
+	c.Check(spec.E, gc.Equals, true)     // Member was marked as exiting.
 
 	leasesResp, err := etcd.Leases(context.Background())
 	c.Check(err, gc.IsNil)

--- a/broker/protocol/broker_spec_extensions.go
+++ b/broker/protocol/broker_spec_extensions.go
@@ -56,9 +56,7 @@ func (m *BrokerSpec) ItemLimit() int { return int(m.JournalLimit) }
 func (m *BrokerSpec) IsExiting() bool { return m.Exiting }
 
 // SetExiting marks this BrokerSpec as exiting.
-// TODO(whb): Zero'ing JournalLimit is for backward compatibility; remove once
-// deployment is complete.
-func (m *BrokerSpec) SetExiting() { m.Exiting = true; m.JournalLimit = 0 }
+func (m *BrokerSpec) SetExiting() { m.Exiting = true }
 
 const (
 	minZoneLen            = 1

--- a/consumer/protocol/shard_spec_extensions.go
+++ b/consumer/protocol/shard_spec_extensions.go
@@ -289,9 +289,7 @@ func (m *ConsumerSpec) ItemLimit() int { return int(m.ShardLimit) }
 func (m *ConsumerSpec) IsExiting() bool { return m.Exiting }
 
 // SetExiting marks this ConsumerSpec as exiting.
-// TODO(whb): Zero'ing ShardLimit is for backward compatibility; remove once
-// deployment is complete.
-func (m *ConsumerSpec) SetExiting() { m.Exiting = true; m.ShardLimit = 0 }
+func (m *ConsumerSpec) SetExiting() { m.Exiting = true }
 
 // Reduce folds another ReplicaStatus into this one.
 func (m *ReplicaStatus) Reduce(other *ReplicaStatus) {


### PR DESCRIPTION
This reverts commit a0705223020b8b2dfb92e63c226a473d181c66d3.

Allocator deployments going forward must first have been running release v0.102.0 prior to deploying on this commit.

I did a fresh round of manual tests here to verify that the transition from brokers on `v0.102.0` to this one works as it should: Old brokers can stop, and these new ones can replace them. Also when all brokers run this new version, they can be started and stopped individually, or as a rolling deployment; or to simulate the unattended upgrades case they can all be restarted at the same time and end up taking turns restarting.