### PR TITLE
broker: fragment list Pathpostfix interning

### DIFF
--- a/broker/protocol/fragment_extensions.go
+++ b/broker/protocol/fragment_extensions.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"unique"
 )
 
 // ContentName returns the content-addressed base file name of this Fragment.
@@ -78,7 +79,7 @@ func ParseFragmentFromRelativePath(journal Journal, name string) (Fragment, erro
 			End:              end,
 			Sum:              SHA1SumFromDigest(sum),
 			CompressionCodec: cc,
-			PathPostfix:      postfix,
+			PathPostfix:      unique.Make(postfix).Value(),
 		}
 	}
 	return f, f.Validate()


### PR DESCRIPTION
Fragment listings include the PathPostfix for every fragment. This had been constructed by a couple of string slices: (1) In `(*store).List` implementations by a `strings.TrimPrefix`, and (2) in `ParseFragmentFromRelativePath` by `path.Dir`.

Taking a slice of a string causes the underlying string to be retained in memory, and this effect is significant if the postfix is relatively short compared to the full fragment path. Additionally, there is often a high degree of overlap in the postfix across journals.

This change uses `unique` to canonicalize the Pathpostfix across fragments to address both of these inefficiencies. The original backing strings will no longer be retained in memory, and only a single full postfix will be retained for every unique occurrence.