### PR TITLE
gazctl: shards prune improvements

### DIFF
--- a/broker/client/list.go
+++ b/broker/client/list.go
@@ -252,6 +252,8 @@ func ListAllFragments(ctx context.Context, client pb.RoutedJournalClient, req pb
 			return resp, mapGRPCCtxErr(ctx, err)
 		} else if err = r.Validate(); err != nil {
 			return resp, err
+		} else if r.Status == pb.Status_SUSPENDED {
+			return resp, ErrSuspended
 		} else if r.Status != pb.Status_OK {
 			return resp, errors.New(r.Status.String())
 		} else {

--- a/cmd/gazctl/gazctlcmd/shards_prune.go
+++ b/cmd/gazctl/gazctlcmd/shards_prune.go
@@ -3,6 +3,7 @@ package gazctlcmd
 import (
 	"context"
 	"errors"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/broker/client"
@@ -12,6 +13,7 @@ import (
 	pc "go.gazette.dev/core/consumer/protocol"
 	"go.gazette.dev/core/consumer/recoverylog"
 	mbp "go.gazette.dev/core/mainboilerplate"
+	"golang.org/x/sync/errgroup"
 )
 
 type cmdShardsPrune struct {
@@ -116,51 +118,68 @@ func (cmd *cmdShardsPrune) Execute([]string) error {
 		mbp.Must(err, "failed to fetch fragments")
 
 		var prunedFragments []pb.Fragment
+
+		var mu sync.Mutex
+		var group errgroup.Group
+		group.SetLimit(32) // Reasonable concurrency for deleting objects from cloud storage
+
 		for _, f := range resp.Fragments {
 			var spec = f.Spec
 
 			metrics.fragmentsTotal++
 			metrics.bytesTotal += spec.ContentLength()
 
-			if !overlapsAnySegment(segments, spec) {
-				if spec.ModTime == 0 {
-					// This shouldn't ever happen, as long as the label selector covers all shards that are using
-					// each journal. But we don't validate that up front, so failing fast is the next best thing.
-					log.WithFields(log.Fields{
-						"journal":        spec.Journal,
-						"name":           spec.ContentName(),
-						"begin":          spec.Begin,
-						"end":            spec.End,
-						"hintedSegments": segments,
-					}).Fatal("unpersisted fragment does not overlap any hinted segments (the label selector argument does not include all shards using this log)")
-				}
-				log.WithFields(log.Fields{
-					"log":   spec.Journal,
-					"name":  spec.ContentName(),
-					"size":  spec.ContentLength(),
-					"mod":   spec.ModTime,
-					"begin": spec.Begin,
-					"end":   spec.End,
-				}).Debug("pruning fragment")
-
-				var removed = true
-				if !cmd.DryRun {
-					if err := fragment.Remove(ctx, spec); err != nil {
-						removed = false
-						metrics.failedToRemove++
-						log.WithFields(log.Fields{
-							"fragment": spec,
-							"error":    err,
-						}).Warn("failed to remove fragment (skipping)")
-					}
-				}
-				if removed {
-					metrics.fragmentsPruned++
-					metrics.bytesPruned += spec.ContentLength()
-					prunedFragments = append(prunedFragments, spec)
-				}
+			if overlapsAnySegment(segments, spec) {
+				continue
 			}
+
+			if spec.ModTime == 0 {
+				// This shouldn't ever happen, as long as the label selector covers all shards that are using
+				// each journal. But we don't validate that up front, so failing fast is the next best thing.
+				log.WithFields(log.Fields{
+					"journal":        spec.Journal,
+					"name":           spec.ContentName(),
+					"begin":          spec.Begin,
+					"end":            spec.End,
+					"hintedSegments": segments,
+				}).Fatal("unpersisted fragment does not overlap any hinted segments (the label selector argument does not include all shards using this log)")
+			}
+
+			log.WithFields(log.Fields{
+				"log":   spec.Journal,
+				"name":  spec.ContentName(),
+				"size":  spec.ContentLength(),
+				"mod":   spec.ModTime,
+				"begin": spec.Begin,
+				"end":   spec.End,
+			}).Debug("pruning fragment")
+
+			group.Go(func() error {
+				var err error
+				if !cmd.DryRun {
+					err = fragment.Remove(ctx, spec)
+				}
+
+				mu.Lock()
+				defer mu.Unlock()
+
+				if err != nil {
+					log.WithFields(log.Fields{
+						"fragment": spec,
+						"error":    err,
+					}).Warn("failed to remove fragment (skipping)")
+					metrics.failedToRemove++
+					return nil
+				}
+				metrics.fragmentsPruned++
+				metrics.bytesPruned += spec.ContentLength()
+				prunedFragments = append(prunedFragments, spec)
+
+				return nil
+			})
 		}
+		_ = group.Wait() // Errors from group workers are logged, so this always returns `nil`
+
 		if len(prunedFragments) > 0 {
 			log.WithFields(log.Fields{
 				"journal":         journal,

--- a/cmd/gazctl/gazctlcmd/shards_prune.go
+++ b/cmd/gazctl/gazctlcmd/shards_prune.go
@@ -2,6 +2,7 @@ package gazctlcmd
 
 import (
 	"context"
+	"errors"
 
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/broker/client"
@@ -102,12 +103,20 @@ func (cmd *cmdShardsPrune) Execute([]string) error {
 
 	for journal, segments := range logSegmentSets {
 		if skipRecoveryLogs[journal] {
-			log.WithField("journal", journal).Warn("skipping journal because a shard is missing hints that cover it or has unlhealthy store")
+			log.WithField("journal", journal).Warn("skipping journal because a shard is missing hints that cover it or has unhealthy store")
 			continue
 		}
 		log.WithField("journal", journal).Debug("checking fragments of journal")
+		var resp, err = client.ListAllFragments(ctx, rjc, pb.FragmentsRequest{Journal: journal})
+		if errors.Is(err, client.ErrSuspended) {
+			metrics.skippedJournals++
+			log.WithField("journal", journal).Debug("skipping suspended recovery log")
+			continue
+		}
+		mbp.Must(err, "failed to fetch fragments")
+
 		var prunedFragments []pb.Fragment
-		for _, f := range fetchFragments(ctx, rjc, journal) {
+		for _, f := range resp.Fragments {
 			var spec = f.Spec
 
 			metrics.fragmentsTotal++
@@ -226,18 +235,6 @@ func overlapsAnySegment(segments []recoverylog.Segment, fragment pb.Fragment) bo
 		return true
 	}
 	return false
-}
-
-func fetchFragments(ctx context.Context, journalClient pb.RoutedJournalClient, journal pb.Journal) []pb.FragmentsResponse__Fragment {
-	var err error
-	var req = pb.FragmentsRequest{
-		Journal: journal,
-	}
-
-	resp, err := client.ListAllFragments(ctx, journalClient, req)
-	mbp.Must(err, "failed to fetch fragments")
-
-	return resp.Fragments
 }
 
 func foldHintsIntoSegments(hints recoverylog.FSMHints, sets map[pb.Journal][]recoverylog.Segment) {


### PR DESCRIPTION
Skip attempting to prune suspended recovery log journals, since they have no fragments list available. There is still an open question of how these suspended recovery log journals should get pruned, since they may contain prunable data, but that is left as a separate exercise. For now, this will just keep the shards prune command from failing fatally any time there is a suspended recovery log journal for the shards matching the selector.

Also, improve execution time by parallelizing fragment removals. A simple `errgroup` directly in the `shards prune` machinery was used, rather than adding a bulk removal method to the `Store` interface. This was a practical choice, since GCS stores don't have a bulk deletion endpoint anyway.