### PR TITLE
broker: fix data race from leaked goroutine in fragment store health test

### DIFF
--- a/broker/fragment_store_health_api_test.go
+++ b/broker/fragment_store_health_api_test.go
@@ -26,6 +26,7 @@ func TestFragmentStoreHealthCases(t *testing.T) {
 	})
 
 	var broker = newTestBroker(t, etcd, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	defer broker.cleanup()
 
 	// Case: health of a valid FragmentStore.
 	var resp, err = broker.client().FragmentStoreHealth(ctx, &pb.FragmentStoreHealthRequest{


### PR DESCRIPTION
TestFragmentStoreHealthCases created a broker via newTestBroker but never called cleanup(), so its resolver watch goroutine outlived the test. When a subsequent test called SetSharedPersister, the leaked goroutine was still reading the sharedPersister global in newReplica, tripping the race detector under `go test -race`.

Add the missing `defer broker.cleanup()` to tear down the broker's tasks.Group at end of test, matching every other broker test.