### PR TITLE
client: retry all append errors when CheckRegisters is set

### DIFF
--- a/broker/client/append_service.go
+++ b/broker/client/append_service.go
@@ -400,6 +400,20 @@ var serveAppends = func(s *AppendService, aa *AsyncAppend, err error) {
 						errors.Is(err2, ErrNotAllowed) ||
 						errors.Is(err2, ErrRegisterMismatch) ||
 						errors.Is(err2, ErrWrongAppendOffset) {
+
+						// TODO(whb): Temporary fix for Flow recovery log
+						// writes, which use CheckRegisters for fencing. These
+						// should be retried indefinitely (until context
+						// cancellation) as there is no way to surface any other
+						// error condition to the caller. Remove this when Flow
+						// no longer relies on the Gazette recovery log
+						// recorder.
+						if aa.app.Request.CheckRegisters != nil &&
+							err2 != context.Canceled && err2 != context.DeadlineExceeded {
+							aa.app.Reset()
+							return err2 // Retry by returning |err2|.
+						}
+
 						err = err2
 						return nil // Break retry loop.
 					} else if err2 != nil {

--- a/broker/client/append_service_test.go
+++ b/broker/client/append_service_test.go
@@ -255,19 +255,11 @@ func (s *AppendServiceSuite) TestAppendNonRetryableErrors(c *gc.C) {
 		status           pb.Status
 		errMsg           string
 		storeHealthError string
-		setupRequest     func(*pb.AppendRequest)
 	}{
 		{
 			status:           pb.Status_FRAGMENT_STORE_UNHEALTHY,
 			errMsg:           "s3: connection timeout: FRAGMENT_STORE_UNHEALTHY",
 			storeHealthError: "s3: connection timeout",
-		},
-		{
-			status: pb.Status_REGISTER_MISMATCH,
-			errMsg: "selector .* doesn't match registers .*: REGISTER_MISMATCH",
-			setupRequest: func(req *pb.AppendRequest) {
-				req.CheckRegisters = &pb.LabelSelector{Include: pb.MustLabelSet("foo", "bar")}
-			},
 		},
 		{
 			status: pb.Status_INDEX_HAS_GREATER_OFFSET,
@@ -295,10 +287,6 @@ func (s *AppendServiceSuite) TestAppendNonRetryableErrors(c *gc.C) {
 		var as = NewAppendService(context.Background(), rjc)
 
 		var req = pb.AppendRequest{Journal: "a/journal"}
-		if tc.setupRequest != nil {
-			tc.setupRequest(&req)
-		}
-
 		var aa = as.StartAppend(req, nil)
 		_, _ = aa.Writer().WriteString("hello, world")
 		c.Check(aa.Release(), gc.IsNil)

--- a/consumer/recoverylog/recorder_test.go
+++ b/consumer/recoverylog/recorder_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"go.gazette.dev/core/broker/client"
 	pb "go.gazette.dev/core/broker/protocol"
@@ -378,6 +379,47 @@ func (s *RecorderSuite) TestContextCancellation(c *gc.C) {
 
 	broker.Tasks.Cancel()
 	c.Check(broker.Tasks.Wait(), gc.IsNil)
+}
+
+func (s *RecorderSuite) TestFencedRecorderBlocksUntilCancelled(c *gc.C) {
+	var (
+		broker, cleanup = newBrokerAndLog(c)
+		ctx, cancel     = context.WithCancel(context.Background())
+		rjc             = pb.NewRoutedJournalClient(broker.Client(), pb.NoopDispatchRouter{})
+		ajc             = client.NewAppendService(ctx, rjc)
+		fsm, _          = NewFSM(FSMHints{Log: aRecoveryLog})
+		rec             = NewRecorder(aRecoveryLog, fsm, anAuthor, "/strip", ajc)
+	)
+	defer cleanup()
+
+	rec.RecordCreate("/strip/file1")
+	c.Check(rec.Barrier(nil).Err(), gc.IsNil)
+
+	// Take the log's registers, as a new primary completing log
+	// hand-off after fail-over would.
+	var fence = client.NewAppender(ctx, rjc, pb.AppendRequest{
+		Journal:        aRecoveryLog,
+		UnionRegisters: otherAuthor.Fence(),
+	})
+	_, _ = fence.Write([]byte("hand-off"))
+	c.Check(fence.Close(), gc.IsNil)
+
+	rec.RecordCreate("/strip/file2")
+	var barrier = rec.Barrier(nil)
+
+	// The barrier must not resolve: its append fails with REGISTER_MISMATCH,
+	// which a register-checked append retries rather than treats as terminal.
+	// A resolved barrier would otherwise tell callers -- like a recorded
+	// RocksDB sync, which cannot check errors -- that the write is durable.
+	select {
+	case <-barrier.Done():
+		c.Fatalf("barrier resolved (err: %v) despite the fence", barrier.Err())
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// Cancelling the processing context releases the (zombie) barrier.
+	cancel()
+	c.Check(barrier.Err(), gc.Equals, context.Canceled)
 }
 
 func (s *RecorderSuite) TestRandomAuthorGeneration(c *gc.C) {


### PR DESCRIPTION
This is a temporary fix to support Flow recovery log writes, which use CheckRegisters for fencing. These should be retried indefinitely (until context cancellation) as there is no way to surface any other error condition to the caller.

To be removed when Flow no longer relies on the Gazette recovery log recorder.